### PR TITLE
Add ocfl-java dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -104,6 +104,16 @@
        </exclusions>
      </dependency>
     <dependency>
+      <groupId>edu.wisc.library.ocfl</groupId>
+      <artifactId>ocfl-java-core</artifactId>
+      <version>1.0.0-SNAPSHOT</version>
+    </dependency>
+    <dependency>
+      <groupId>edu.wisc.library.ocfl</groupId>
+      <artifactId>ocfl-java-api</artifactId>
+      <version>1.0.0-SNAPSHOT</version>
+    </dependency>
+    <dependency>
       <groupId>commons-io</groupId>
       <artifactId>commons-io</artifactId>
       <version>2.4</version>
@@ -188,6 +198,13 @@
   </dependencies>
 
   <repositories>
+
+    <!--Remove this once Peter Winkles publishes to Sonatype-->
+    <repository>
+      <id>tmp-dependencies</id>
+      <name>Temporary Dependencies</name>
+      <url>https://raw.github.com/awoods/dependencies/master/</url>
+    </repository>
 
     <repository>
       <id>sonatype-nexus-snapshots</id>


### PR DESCRIPTION
Resolves: https://jira.duraspace.org/browse/FCREPO-3045

Note, the 'repositories' update in the pom.xml should be reverted when the ocfl-java artifacts are published to Sonatype

# What does this Pull Request do?
Adds ocfl-java dependencies

# How should this be tested?
Build the application, dependencies should be downloaded.

# Interested parties
@fcrepo4-exts/migration-utils-committers 
