### PR TITLE
Fcrepo 3055

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -49,7 +49,7 @@
     <dependency>
         <groupId>commons-codec</groupId>
         <artifactId>commons-codec</artifactId>
-        <version>1.6</version>
+        <version>1.13</version>
       </dependency>
      <dependency>
       <groupId>org.apache.jena</groupId>


### PR DESCRIPTION
**Migration utils: Upgrade commons-codec version to match UWM OCFL lib**
* * *

https://jira.duraspace.org/browse/FCREPO-3055

# What does this Pull Request do?
Updates commons-codec version from 1.6 to 1.13 to meet dependencies from ocfl-java 
Due to https://github.com/UW-Madison-Library/ocfl-java/commit/bdcf59e9694f94f3bf3e873c0a0e0cbb526a3187 seemingly breaking migration-utils build

# What's new?
* pom.xml version change for commons-codec from 1.6 to 1.13 


# How should this be tested?

Ensure commons-codec functionality in https://github.com/fcrepo4-exts/migration-utils/blob/master/src/main/java/org/fcrepo/migration/foxml/FoxmlInputStreamFedoraObjectProcessor.java#L356 is unaffected by the upgrade. 

# Interested parties
@fcrepo4/committers 
