### PR TITLE
Removed testing with JDK8 from Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: java
 sudo: required
 jdk:
-  - openjdk8
   - openjdk11
 go:
   - 1.12.x

--- a/src/main/java/org/fcrepo/migration/f4clients/OCFLFedora4Client.java
+++ b/src/main/java/org/fcrepo/migration/f4clients/OCFLFedora4Client.java
@@ -42,6 +42,7 @@ public class OCFLFedora4Client implements Fedora4Client {
      * @since 4.4.1-SNAPSHOT
      * @param storage Root for OCFL Objects
      * @param staging directory for in-progress OCFL Objects
+     * @param mapper to be used to map object id's to paths
      */
     public OCFLFedora4Client(final String storage, final String staging, final ObjectIdMapperType mapper) {
 

--- a/src/test/java/org/fcrepo/migration/f4clients/OCFLFedora4ClientTest.java
+++ b/src/test/java/org/fcrepo/migration/f4clients/OCFLFedora4ClientTest.java
@@ -22,7 +22,7 @@ public class OCFLFedora4ClientTest {
      * @throws java.lang.Exception
      */
     @BeforeClass
-    public static void setUp() throws Exception {
+    public static void setUp() {
 
         final String storage = "src/test/resources/ocflStorage";
         final String staging = "src/test/resources/staging";

--- a/src/test/java/org/fcrepo/migration/f4clients/OCFLFedora4ClientTest.java
+++ b/src/test/java/org/fcrepo/migration/f4clients/OCFLFedora4ClientTest.java
@@ -18,9 +18,6 @@ public class OCFLFedora4ClientTest {
 
     private static OCFLFedora4Client client;
 
-    /**
-     * @throws java.lang.Exception
-     */
     @BeforeClass
     public static void setUp() {
 

--- a/src/test/resources/staging/.gitignore
+++ b/src/test/resources/staging/.gitignore
@@ -1,0 +1,4 @@
+# Ignore everything in this directory
+*
+# Except this file
+!.gitignore


### PR DESCRIPTION
**Removed testing with JDK8 from Travis**
* * *

**JIRA Ticket**: https://jira.duraspace.org/browse/FCREPO-3068

# What does this Pull Request do?
* Removed jdk8 from Travis configuration file. JDK8 is no longer supported by the project.
* Added missing testing resource: test/resources/staging
* Cosmetic changes

# How should this be tested?
Travis should no longer report broken builds for Java 8

# Interested parties
@Surfrdan @pwinckles
