### PR TITLE
Allow selection of PIDs/Objects to migrate with to new selectors

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,12 +56,25 @@ The system properties determine the specific details of the migration, and are d
 * `migration.namespace.file`.  RDF namespace file.  Default  ***`src/main/resources/namespaces.properties`***
 * `migration.ocfl.storage.dir`.  Path to OCFL storage dir.  Only relevant when `fedora.client` is `ocfl`.  Default ***`target/test/ocfl`***
 * `migration.ocfl.staging.dir`.  Path to OCFL staging dir.  Only relevant when `fedora.client` is `ocfl`. Default ***`target/test/staging`***
+* `migration.pid.list.file`.  File containing list of PIDs to migrate.  Only relevant when `fedora.client` is `ocfl`. Default ***`null`***
+* `migration.pid.resume.dir`.  Path to directory in which a "resume file" will be created/used in the case that a previous run must be resumed from the last exported PID/Object.  Only relevant when `fedora.client` is `ocfl`. Default ***`target/test/pid`***
+* `migration.pid.resume.all`.  Boolean flag indicating whether the current execution should resume from the last exported PID/Object of process from the beginning.  Only relevant when `fedora.client` is `ocfl`. Default ***`true`***
 * `fedora.client`.  {fedora4, ocfl} Client to use for populating a fedora instance.  `fedora4` is an HTTP client used to populate Fedora via its APIs.  `ocfl` is a client that writes OCFL objects to a filesystem, rather than an HTTP API.  They are suitable only for migrating to Fedora 6.  Default: ***`fedora4`***
 * `fedora.from.server`.  Host and port of a fedora3, not sure what it is used for.  Default: ***localhost:8080***
 * `fedora.to.baseuri`.  For full ldp-based migration (when the `fedora.client` is `fedora4`), the Fedora baseURI you want triples to be migrated to, and/or the Fedora you want to deposit content into.  Default ***http://localhost:${fcrepo.dynamic.test.port:8080}/rest/***
 * `foxml.export.dir`: When using the exported foxml layout, this is the directory containing exported foxml.  Default ***src/test/resources/exported***
 * `foxml.datastream.dir`.  Datastream directory for legacy and akubra layouts.  Default is ***src/test/resources/legacyFS/datastreams***
 * `foxml.object.dir`.  Foxml object dir for legacy and akubra layouts.  Default is ***src/test/resources/legacyFS/objects***
+
+### PID migration selection
+
+The default migration configuration will migrate all of the Fedora 2/3 objects found in the source. Subsequent runs will simply re-migrate all of those objects.
+However, there are circumstances when it is preferred that only a subset of all source objects be migrated.
+There are three means by which a subset of objects may be selected for migration (noting that these means may also be combined).
+* *Limit*: When setting the `limit` configuration (detailed above), the migration will be performed on first X-number of objects specified by the value of `limit`.
+* *PID List*: When a pid-list is provided (detailed above), the migration will only be performed on the objects associated with the PIDs in the provided pid-list file.
+* *Resume*: When enabling the `resume` configuration (detailed above), a file is maintained that keeps track of the last successfully migration object. Subsequent executions will only migrate objects following the last migrated object. Note, this capability is based on the assumption that the order of objects to be migrated is deterministic and the same from one execution to the next.
+
 
 ### Examples
 

--- a/pom.xml
+++ b/pom.xml
@@ -325,6 +325,16 @@
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <version>3.0.0-M3</version>
+        <configuration>
+          <systemPropertyVariables>
+            <test.output.dir>${project.build.directory}</test.output.dir>
+          </systemPropertyVariables>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-failsafe-plugin</artifactId>
         <configuration>
           <!-- export ports for integration tests to system.env-->

--- a/src/main/java/org/fcrepo/migration/pidlist/PidListManager.java
+++ b/src/main/java/org/fcrepo/migration/pidlist/PidListManager.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2015 DuraSpace, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.fcrepo.migration.pidlist;
+
+/**
+ * PidListManager implementations indicate that the Fedora Object associated with a PID
+ *  should be processed, or not.
+ *
+ * @author awoods
+ * @since 2019-11-08
+ */
+public interface PidListManager {
+
+    /**
+     * This method returns true if the the provided PID should be processed
+     *
+     * @param pid associated with a Fedora Object to potentially be processed
+     * @return true if Object should be processed
+     */
+    boolean accept(String pid);
+
+
+}

--- a/src/main/java/org/fcrepo/migration/pidlist/ResumePidListManager.java
+++ b/src/main/java/org/fcrepo/migration/pidlist/ResumePidListManager.java
@@ -1,0 +1,175 @@
+/*
+ * Copyright 2015 DuraSpace, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.fcrepo.migration.pidlist;
+
+import org.slf4j.Logger;
+
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.FileReader;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.io.PrintWriter;
+
+import static org.slf4j.LoggerFactory.getLogger;
+
+/**
+ * This class "accepts" PIDs that have not already been migrated.
+ * <p>
+ * The approach taking by this implementation is to record:
+ * - the number of objects that have been migrated, and
+ * - the PID of the last migrated object
+ * <p>
+ * The assumption is that the order of processed PIDs/Objects is deterministic
+ *
+ * @author awoods
+ * @since 2019-11-08
+ */
+public class ResumePidListManager implements PidListManager {
+
+    private static final Logger LOGGER = getLogger(ResumePidListManager.class);
+
+    private File resumeFile;
+
+    // Accept all PIDs, even if they have been processed before
+    private boolean acceptAll;
+
+    // Position of the last processed PID/Object (assuming deterministic ordering)
+    private int pidResumeIndex;
+
+    // Value of the last processed PID/Object
+    private String pidResumeValue;
+
+    // Number of times "accept" has been called
+    private int index = 0;
+
+    // Last value of current PID
+    private String value = "foo";
+
+
+    /**
+     * Constructor
+     *
+     * @param pidDir where resume file will be read/created
+     */
+    public ResumePidListManager(final File pidDir, final boolean acceptAll) {
+        if (!pidDir.exists()) {
+            pidDir.mkdirs();
+        }
+
+        if (!pidDir.isDirectory()) {
+            throw new IllegalArgumentException("Arg must be a directory: " + pidDir.getAbsolutePath());
+        }
+
+        this.acceptAll = acceptAll;
+        this.resumeFile = new File(pidDir, "resume.txt");
+        LOGGER.debug("Resume pid file: {}, accept all? {}", resumeFile.getAbsolutePath(), acceptAll);
+
+        try {
+            // Load pidResumeIndex and pidResumeValue
+            loadResumeFile();
+
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private void loadResumeFile() throws IOException {
+
+        // First run? file does not yet exist?
+        if (!resumeFile.exists() || resumeFile.length() == 0) {
+            updateResumeFile(value, index);
+        }
+
+        final BufferedReader reader = new BufferedReader(new FileReader(resumeFile));
+
+        // First line contains PID
+        pidResumeValue = reader.readLine();
+
+        // Second line contains index
+        pidResumeIndex = Integer.parseInt(reader.readLine());
+    }
+
+
+    /**
+     * This method
+     * - returns false if "accept" has been called less than pidResumeIndex times
+     * - returns true if "accept" has been called
+     */
+    @Override
+    public boolean accept(final String pid) {
+        final String logMsg = "PID: " + pid + ", accept? ";
+
+        final String previousValue = value;
+        value = pid;
+        index++;
+
+        // Do not accept.. the previous run index is higher
+        if (index - 1 < pidResumeIndex) {
+
+            // Are we accepting all?
+            LOGGER.debug(logMsg + acceptAll);
+            return acceptAll;
+        }
+
+        // We are at the first PID that has not previously been processed
+        if (index - 1 == pidResumeIndex) {
+
+            // index matches, but value DOES NOT match the last state of previous run!
+            if (!previousValue.equalsIgnoreCase(pidResumeValue)) {
+                final String msg = "Number of accept requests does not align with expected PID value! " +
+                        "index: " + index + ", " +
+                        "pid: " + pid + ", " +
+                        "expected pid: " + pidResumeValue;
+                throw new IllegalStateException(msg);
+            }
+        }
+
+        // New "accept" requests
+        updateResumeFile(value, index);
+
+        LOGGER.debug(logMsg + true);
+        return true;
+    }
+
+    /**
+     * This method resets the current index and value, and resets the resume file
+     * -- Used for test --
+     */
+    void reset() {
+        index = 0;
+        value = "foo";
+        updateResumeFile(value, index);
+    }
+
+    private void updateResumeFile(final String pid, final int index) {
+        // Create writer of resumeFile (expense to do everytime... but need to overwrite file)
+        PrintWriter resumeFileWriter = null;
+        try {
+            resumeFileWriter = new PrintWriter(new FileWriter(resumeFile, false));
+
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+
+        resumeFileWriter.write(pid);
+        resumeFileWriter.write(System.getProperty("line.separator"));
+        resumeFileWriter.write(Integer.toString(index));
+
+        resumeFileWriter.flush();
+        resumeFileWriter.close();
+    }
+}

--- a/src/main/java/org/fcrepo/migration/pidlist/UserProvidedPidListManager.java
+++ b/src/main/java/org/fcrepo/migration/pidlist/UserProvidedPidListManager.java
@@ -1,0 +1,59 @@
+package org.fcrepo.migration.pidlist;
+
+import org.slf4j.Logger;
+
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.FileReader;
+import java.util.HashSet;
+import java.util.Set;
+
+import static org.slf4j.LoggerFactory.getLogger;
+
+/**
+ * This class "accepts" and PIDs that are included in the user-provided list
+ *
+ * @author awoods
+ * @since 2019-11-08
+ */
+public class UserProvidedPidListManager implements PidListManager {
+
+    private static final Logger LOGGER = getLogger(UserProvidedPidListManager.class);
+
+    private Set<String> pidList = new HashSet<>();
+
+    /**
+     * Constructor
+     *
+     * @param pidListFile provided by user
+     */
+    public UserProvidedPidListManager(final File pidListFile) {
+
+        // If arg is null, we will accept all PIDs
+        if (pidListFile != null) {
+            if (!pidListFile.exists() || !pidListFile.canRead()) {
+                throw new IllegalArgumentException("File either does not exist or is inaccessible :" +
+                        pidListFile.getAbsolutePath());
+            }
+
+            BufferedReader reader = null;
+            try {
+                reader = new BufferedReader(new FileReader(pidListFile));
+            } catch (FileNotFoundException e) {
+                // Should not happen based on previous check
+                throw new RuntimeException(e);
+            }
+
+            reader.lines().forEach(l -> pidList.add(l));
+        }
+    }
+
+
+    @Override
+    public boolean accept(final String pid) {
+        final boolean doAccept =  pidList.isEmpty() || pidList.contains(pid);
+        LOGGER.debug("PID: {}, accept? {}", pid, doAccept);
+        return doAccept;
+    }
+}

--- a/src/test/java/org/fcrepo/migration/pidlist/ResumePidListManagerIT.java
+++ b/src/test/java/org/fcrepo/migration/pidlist/ResumePidListManagerIT.java
@@ -1,0 +1,122 @@
+/**
+ * Copyright 2015 DuraSpace, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.fcrepo.migration.pidlist;
+
+import org.apache.commons.io.FileUtils;
+import org.apache.commons.io.filefilter.RegexFileFilter;
+import org.fcrepo.migration.Migrator;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.springframework.context.ConfigurableApplicationContext;
+import org.springframework.context.support.ClassPathXmlApplicationContext;
+
+import java.io.File;
+import java.io.FileFilter;
+import java.util.Collections;
+
+/**
+ * A basic suite of integration tests to test certain interaction patterns (and code) against the an OCFL version of
+ * Fedora.
+ * ..using the "ResumePidListManager"
+ *
+ * @author awoods
+ * @since 2019-11-11
+ */
+public class ResumePidListManagerIT {
+
+    private ConfigurableApplicationContext context;
+    private Migrator migrator;
+    private File storage;
+    private File staging;
+    private File pidDir;
+
+    @Before
+    public void setup() throws Exception {
+        // Create directories expected in this test (based on `spring/ocfl-pid-it-setup.xml`)
+        storage = new File("target/test/ocfl/pid-it/storage");
+        staging = new File("target/test/ocfl/pid-it/staging");
+        pidDir = new File("target/test/ocfl/pid-it/pid");
+
+        if (storage.exists()) {
+            FileUtils.forceDelete(storage);
+        }
+        if (staging.exists()) {
+            FileUtils.forceDelete(staging);
+        }
+        if (pidDir.exists()) {
+            FileUtils.forceDelete(pidDir);
+        }
+
+        storage.mkdirs();
+        staging.mkdirs();
+        pidDir.mkdirs();
+
+        context = new ClassPathXmlApplicationContext("spring/ocfl-pid-it-setup.xml");
+        migrator = (Migrator) context.getBean("migrator");
+    }
+
+    @After
+    public void tearDown() {
+        context.close();
+    }
+
+    @Test
+    public void testMigrate() throws Exception {
+        final boolean acceptAll = false;
+        final ResumePidListManager manager = new ResumePidListManager(pidDir, acceptAll);
+
+        // There are three test OCFL objects: example%3a1, example%3a2, example%3a3
+        migrator.setPidListManagers(Collections.singletonList(manager));
+        migrator.run();
+
+        final int numObjects = storage.listFiles((FileFilter) new RegexFileFilter("example.*")).length;
+        Assert.assertEquals(3, numObjects);
+    }
+
+    @Test
+    public void testMigrateIncremental() throws Exception {
+        final boolean acceptAll = false;
+
+        // There are three test OCFL objects: example%3a1, example%3a2, example%3a3
+        migrator.setPidListManagers(Collections.singletonList(new ResumePidListManager(pidDir, acceptAll)));
+        // Only migrate 2 of 3 objects
+        migrator.setLimit(2);
+        migrator.run();
+        context.close();
+
+        int numObjects = storage.listFiles((FileFilter) new RegexFileFilter("example.*")).length;
+        Assert.assertEquals(2, numObjects);
+
+        // Remove the previously exported objects, and resume the migration
+        FileUtils.forceDelete(storage);
+        FileUtils.forceDelete(staging);
+        storage.mkdirs();
+        staging.mkdirs();
+
+        context = new ClassPathXmlApplicationContext("spring/ocfl-pid-it-setup.xml");
+        migrator = (Migrator) context.getBean("migrator");
+        migrator.setPidListManagers(Collections.singletonList(new ResumePidListManager(pidDir, acceptAll)));
+        migrator.setLimit(-1); // migrate all
+        migrator.run();
+
+        numObjects = storage.listFiles((FileFilter) new RegexFileFilter("example.*")).length;
+        Assert.assertEquals(1, numObjects);
+    }
+
+}

--- a/src/test/java/org/fcrepo/migration/pidlist/ResumePidListManagerTest.java
+++ b/src/test/java/org/fcrepo/migration/pidlist/ResumePidListManagerTest.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright 2015 DuraSpace, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.fcrepo.migration.pidlist;
+
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.File;
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * Unit test class for ResumePidListManager
+ *
+ * @author awoods
+ * @since 2019-11-08
+ */
+public class ResumePidListManagerTest {
+
+    private ResumePidListManager manager;
+    private final String testDir = System.getProperty("test.output.dir");
+
+    private List<String> pidList;
+
+    @Before
+    public void setUp() {
+        // Test PIDs
+        pidList = Arrays.asList("pid:1", "pid:2", "pid:3", "pid:4");
+
+        System.out.println("test dir: " + testDir);
+
+        // Define directory in which to find resume-file.
+        manager = new ResumePidListManager(new File(testDir), false);
+    }
+
+    @After
+    public void tearDown() {
+        manager.reset();
+    }
+
+    @Test
+    public void accept() {
+        pidList.forEach(pid -> Assert.assertTrue(pid + " should be accepted", manager.accept(pid)));
+    }
+
+    @Test
+    public void acceptIncrementalRuns() {
+        Assert.assertTrue("pid:1 should be accepted", manager.accept("pid:1"));
+        Assert.assertTrue("pid:2 should be accepted", manager.accept("pid:2"));
+
+        // Simulate stopping the migration process... and start over
+        manager = new ResumePidListManager(new File(testDir), false);
+        Assert.assertFalse("pid:1 should NOT be accepted", manager.accept("pid:1"));
+        Assert.assertFalse("pid:2 should NOT be accepted", manager.accept("pid:2"));
+
+        // ..however, unprocessed PIDs should be "accepted"
+        Assert.assertTrue("pid:3 should be accepted", manager.accept("pid:3"));
+        Assert.assertTrue("pid:4 should be accepted", manager.accept("pid:4"));
+
+        // Starting over again... no PIDs should be accepted
+        manager = new ResumePidListManager(new File(testDir), false);
+        pidList.forEach(pid -> Assert.assertFalse(pid + " should NOT be accepted", manager.accept(pid)));
+    }
+
+    @Test
+    public void acceptAll() {
+        Assert.assertTrue("pid:1 should be accepted", manager.accept("pid:1"));
+        Assert.assertTrue("pid:2 should be accepted", manager.accept("pid:2"));
+
+        // Simulate stopping the migration process... and start over - but accept all
+        manager = new ResumePidListManager(new File(testDir), true);
+        Assert.assertTrue("pid:1 should be accepted", manager.accept("pid:1"));
+        Assert.assertTrue("pid:2 should be accepted", manager.accept("pid:2"));
+
+        // ..however, unprocessed PIDs should be "accepted" - accept all
+        Assert.assertTrue("pid:3 should be accepted", manager.accept("pid:3"));
+        Assert.assertTrue("pid:4 should be accepted", manager.accept("pid:4"));
+
+        // Starting over again... no PIDs should be accepted - but, accept all
+        manager = new ResumePidListManager(new File(testDir), true);
+        pidList.forEach(pid -> Assert.assertTrue(pid + " should be accepted", manager.accept(pid)));
+    }
+}

--- a/src/test/java/org/fcrepo/migration/pidlist/UserProvidedPidListManagerIT.java
+++ b/src/test/java/org/fcrepo/migration/pidlist/UserProvidedPidListManagerIT.java
@@ -1,0 +1,119 @@
+/**
+ * Copyright 2015 DuraSpace, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.fcrepo.migration.pidlist;
+
+import org.apache.commons.io.FileUtils;
+import org.apache.commons.io.filefilter.RegexFileFilter;
+import org.fcrepo.migration.Migrator;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.springframework.context.ConfigurableApplicationContext;
+import org.springframework.context.support.ClassPathXmlApplicationContext;
+
+import java.io.BufferedWriter;
+import java.io.File;
+import java.io.FileFilter;
+import java.io.FileWriter;
+import java.util.Collections;
+
+/**
+ * A basic suite of integration tests to test certain interaction patterns (and code) against the an OCFL version of
+ * Fedora.
+ * ..using the "UserProvidePidListManager"
+ *
+ * @author awoods
+ * @since 2019-11-11
+ */
+public class UserProvidedPidListManagerIT {
+
+    private ConfigurableApplicationContext context;
+    private Migrator migrator;
+    private File storage;
+    private File staging;
+    private File pidFile;
+
+    @Before
+    public void setup() throws Exception {
+        // Create directories expected in this test (based on `spring/ocfl-user-it-setup.xml`)
+        storage = new File("target/test/ocfl/user-it/storage");
+        staging = new File("target/test/ocfl/user-it/staging");
+        pidFile = new File("target/test/ocfl/user-it/pidlist.txt");
+
+        if (storage.exists()) {
+            FileUtils.forceDelete(storage);
+        }
+        if (staging.exists()) {
+            FileUtils.forceDelete(staging);
+        }
+        if (pidFile.exists()) {
+            FileUtils.forceDelete(pidFile);
+        }
+
+        storage.mkdirs();
+        staging.mkdirs();
+
+        context = new ClassPathXmlApplicationContext("spring/ocfl-user-it-setup.xml");
+        migrator = (Migrator) context.getBean("migrator");
+    }
+
+    @After
+    public void tearDown() {
+        context.close();
+    }
+
+    @Test
+    public void testMigrate() throws Exception {
+        // Create PID-list file
+        final BufferedWriter writer = new BufferedWriter(new FileWriter(pidFile));
+        writer.write("example:3");
+        writer.newLine();
+        writer.write("example:2");
+        writer.newLine();
+        writer.write("example:1");
+        writer.flush();
+
+        final UserProvidedPidListManager manager = new UserProvidedPidListManager(pidFile);
+
+        // There are three test OCFL objects: example%3a1, example%3a2, example%3a3
+        migrator.setPidListManagers(Collections.singletonList(manager));
+        migrator.run();
+
+        final int numObjects = storage.listFiles((FileFilter) new RegexFileFilter("example.*")).length;
+        Assert.assertEquals(3, numObjects) ;
+    }
+
+    @Test
+    public void testMigrateIncremental() throws Exception {
+        // Create PID-list file
+        final BufferedWriter writer = new BufferedWriter(new FileWriter(pidFile));
+        writer.write("example:3");
+        writer.newLine();
+        writer.write("example:1");
+        writer.flush();
+
+        // There are three test OCFL objects: example%3a1, example%3a2, example%3a3
+        migrator.setPidListManagers(Collections.singletonList(new UserProvidedPidListManager(pidFile)));
+        migrator.run();
+        context.close();
+
+        final int numObjects = storage.listFiles((FileFilter) new RegexFileFilter("example.*")).length;
+        Assert.assertEquals(2, numObjects);
+    }
+
+}

--- a/src/test/java/org/fcrepo/migration/pidlist/UserProvidedPidListManagerTest.java
+++ b/src/test/java/org/fcrepo/migration/pidlist/UserProvidedPidListManagerTest.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2015 DuraSpace, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.fcrepo.migration.pidlist;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.BufferedWriter;
+import java.io.File;
+import java.io.FileWriter;
+import java.util.Arrays;
+import java.util.List;
+
+
+/**
+ * Unit test class for UserProvidedPidListManager
+ *
+ * @author awoods
+ * @since 2019-11-08
+ */
+public class UserProvidedPidListManagerTest {
+
+    private UserProvidedPidListManager manager;
+
+    private List<String> pidList;
+
+    private File pidListFile;
+
+    @Before
+    public void setUp() throws Exception {
+        // Test PIDs
+        pidList = Arrays.asList("pid:1", "pid:2", "pid:3", "pid:4");
+
+        // Create file in which to place test PIDs
+        final String testDir = System.getProperty("test.output.dir");
+        final StringBuilder tmpList = new StringBuilder();
+        pidList.forEach(pid -> tmpList.append(pid).append("\n"));
+
+        pidListFile = new File(testDir, "pid-list.txt");
+
+        final BufferedWriter writer = new BufferedWriter(new FileWriter(pidListFile));
+        writer.write(tmpList.toString());
+        writer.close();
+
+        // Class under test
+        manager = new UserProvidedPidListManager(pidListFile);
+    }
+
+    @Test
+    public void accept() {
+        pidList.forEach(pid -> Assert.assertTrue(pid + " should be accepted", manager.accept(pid)));
+    }
+
+    @Test
+    public void acceptAll() {
+        manager = new UserProvidedPidListManager(null);
+        pidList.forEach(pid -> Assert.assertTrue(pid + " should be accepted", manager.accept(pid)));
+    }
+
+
+    @Test
+    public void acceptNotFound() {
+        Assert.assertFalse("'bad' should NOT be accepted", manager.accept("bad"));
+        Assert.assertFalse("'junk' should NOT be accepted", manager.accept("junk"));
+    }
+}

--- a/src/test/resources/spring/ocfl-pid-it-setup.xml
+++ b/src/test/resources/spring/ocfl-pid-it-setup.xml
@@ -1,51 +1,30 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!--
-  This configuration file serves as a starting point for a fedora 3 to fedora 4
-   migration when the fedora 3 content has been exported to "archive" FOXML 1.1
-   files.
-
-  There are several default values you will likely have to change below, each is
-  marked with a comment starting with "CHANGE THIS":
--->
-    <beans xmlns="http://www.springframework.org/schema/beans"
+<beans xmlns="http://www.springframework.org/schema/beans"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-       xmlns:context="http://www.springframework.org/schema/context"
-       xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-           http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-3.0.xsd">
+       xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd">
 
-    <context:property-placeholder/>
+    <!-- Main Migrator -->
 
     <bean id="migrator" class="org.fcrepo.migration.Migrator">
-        <property name="source" ref="${migration.layout:exported}" />
+        <property name="source" ref="exported" />
         <property name="handler" ref="objectAbstraction" />
-        <property name="limit" value="${migration.limit:2}" /><!-- SET migration.limit OR CHANGE THIS IF YOU WANT TO MIGRATE MORE THAN 2 OBJECTS -->
-        <!--PID List Managers help in selecting which source objects to migration, default is ALL-->
-        <property name="pidListManagers">
-            <list>
-                <bean class="org.fcrepo.migration.pidlist.UserProvidedPidListManager">
-                    <constructor-arg name="pidListFile" value="${migration.pid.list.file:#{null}}"/>
-                </bean>
-                <bean class="org.fcrepo.migration.pidlist.ResumePidListManager">
-                    <constructor-arg name="pidDir" value="${migration.pid.resume.dir:target/test/pid}"/>
-                    <constructor-arg name="acceptAll" value="${migration.pid.resume.all:true}"/>
-                </bean>
-            </list>
-        </property>
+        <property name="limit" value="-1" />
     </bean>
+
 
     <bean id="exported" class="org.fcrepo.migration.foxml.ArchiveExportedFoxmlDirectoryObjectSource" lazy-init="true">
         <constructor-arg name="exportDir" ref="exportDir" />
         <constructor-arg name="localFedoraServer" ref="localFedoraServer" />
         <property name="fetcher" ref="httpClientURLFetcher"/>
     </bean>
-    
+
     <bean id="legacy" class="org.fcrepo.migration.foxml.NativeFoxmlDirectoryObjectSource" lazy-init="true">
         <constructor-arg name="objectStore" ref="objectStore" />
         <constructor-arg name="resolver" ref="legacyIDResolver" />
         <constructor-arg name="localFedoraServer" ref="localFedoraServer" />
         <property name="fetcher" ref="httpClientURLFetcher"/>
     </bean>
-    
+
     <bean id="akubra" class="org.fcrepo.migration.foxml.NativeFoxmlDirectoryObjectSource" lazy-init="true">
         <constructor-arg name="objectStore" ref="objectStore" />
         <constructor-arg name="resolver" ref="akubraIDResolver" />
@@ -60,7 +39,7 @@
              the repository changes.  -->
         <!--  <constructor-arg name="indexDir" type="java.io.File" ref="indexRoot" /> -->
     </bean>
-    
+
     <bean id="akubraIDResolver" class="org.fcrepo.migration.foxml.AkubraFSIDResolver" lazy-init="true">
         <constructor-arg name="dsRoot" type="java.io.File" ref="datastreamStore"/>
         <!-- Add the following line back in if you wish to maintain a cache of the internal id mapping between
@@ -68,62 +47,40 @@
              the repository changes.  -->
         <!--<constructor-arg name="indexDir" type="java.io.File" ref="indexRoot" />-->
     </bean>
-    
-    
+
+
     <!-- Set foxml.dir.objects or CHANGE THIS TO YOUR FEDORA 3 OBJECTS DIRECTORY -->
     <bean id="objectStore" class="java.io.File">
-        <constructor-arg type="java.lang.String" value="${foxml.object.dir:src/test/resources/legacyFS/objects}" />
+        <constructor-arg type="java.lang.String" value="src/test/resources/legacyFS/objects" />
     </bean>
 
     <!-- Set foxml.store.datastreams or CHANGE THIS TO YOUR FEDORA 3 DATASTREAM DIRECTORY -->
     <bean id="datastreamStore" class="java.io.File">
-        <constructor-arg type="java.lang.String" value="${foxml.datastream.dir:src/test/resources/legacyFS/datastreams}" />
-    </bean>  
-    
+        <constructor-arg type="java.lang.String" value="src/test/resources/legacyFS/datastreams" />
+    </bean>
+
     <bean id="indexRoot" class="java.io.File">
-        <constructor-arg type="java.lang.String" value="${migration.index.root:index}" />
-    </bean>  
+        <constructor-arg type="java.lang.String" value="target/test/ocfl/pid-it/index}" />
+    </bean>
 
     <bean id="objectAbstraction" class="org.fcrepo.migration.handlers.ObjectAbstractionStreamingFedoraObjectHandler">
         <constructor-arg ref="versionAbstraction"/>
     </bean>
 
     <bean id="versionAbstraction" class="org.fcrepo.migration.handlers.VersionAbstractionFedoraObjectHandler">
-        <constructor-arg ref="${migration.strategy:ldpFull}"/>
+        <constructor-arg ref="minimal"/>
     </bean>
-
-    <!-- Full LDP migration impl -->
-    <bean id="ldpFull" class="org.fcrepo.migration.handlers.BasicObjectVersionHandler">
-        <constructor-arg name="client" ref="${fedora.client:ocfl}" />
-        <constructor-arg name="idMapper" ref="idMapper" />
-        <constructor-arg name="localFedoraServer" ref="localFedoraServer" />
-        <constructor-arg name="namespacePrefixMapper" ref="namespacePrefixMapper"/>
-        <property name="customPropertyMapping" ref="propertiesFile" />
-        <property name="importExternal" value="${migration.import.external:false}" /><!-- CHANGE THIS IF YOU WANT TO IMPORT E DATASTREAMS -->
-        <property name="importRedirect" value="${migration.import.redirect:false}" /><!-- CHANGE THIS IF YOU WANT TO IMPORT R DATASTREAMS -->
-    </bean>
-
-    <!--
-       Mints a new fedora 4 path for each PID encountered during the migration.
-       The mappings are persisted in a lucene index configured in the "idIndex"
-       bean.  Furthermore, a file id-minter.log will contain the mapping as well.
-    -->
-    <bean id="idMapper" class="org.fcrepo.migration.idmappers.OpaqueIDMapper">
-        <constructor-arg name="cachedIDIndexDir" ref="idIndex" />
-        <constructor-arg name="f4Client" ref="${fedora.client:ocfl}" />
-    </bean>
-
 
     <bean id="namespacePrefixMapper" class="org.fcrepo.migration.foxml.NamespacePrefixMapper">
         <constructor-arg name="namespaceFile" type="java.io.File" ref="namespaceFile"/>
     </bean>
-    
+
     <bean id="minimal" class="org.fcrepo.migration.handlers.ocfl.ArchiveGroupHandler">
-    	<constructor-arg name="driver" ref="ocflDriver" />
+        <constructor-arg name="driver" ref="ocflDriver" />
     </bean>
-    
+
     <bean id="ocflDriver" class="org.fcrepo.migration.handlers.ocfl.HackyOcflDriver">
-        <constructor-arg ref="${fedora.client:ocfl}"/>
+        <constructor-arg ref="ocfl"/>
     </bean>
 
     <bean id="fedora4" class="org.fcrepo.migration.f4clients.StatelessFedora4Client">
@@ -132,10 +89,10 @@
         <!--<constructor-arg name="username" value="admin-username"/>-->
         <!--<constructor-arg name="password" value="admin-password"/>-->
     </bean>
-    
+
     <bean id="ocfl" class="org.fcrepo.migration.f4clients.OCFLFedora4Client" destroy-method="close">
-        <constructor-arg name="storage" value="${migration.ocfl.storage.dir:target/test/storage}"/>
-        <constructor-arg name="staging" value="${migration.ocfl.staging.dir:target/test/staging}"/>
+        <constructor-arg name="storage" value="target/test/ocfl/pid-it/storage"/>
+        <constructor-arg name="staging" value="target/test/ocfl/pid-it/staging"/>
         <constructor-arg name="mapper" value="FLAT"/>
     </bean>
 
@@ -143,25 +100,25 @@
 
     <!-- CHANGE THIS TO THE FEDORA 4 URL TO WHICH YOU WANT TO MIGRATE THE CONTENT -->
     <bean id="fedora4Url" class="java.lang.String">
-        <constructor-arg value="${fedora.to.baseuri:http://localhost:${fcrepo.dynamic.test.port:8080}/rest/}" />
+        <constructor-arg value="http://localhost:${fcrepo.dynamic.test.port:8080}/rest/" />
     </bean>
 
     <!-- The fedora 2 or 3 server migrated content is coming from -->
     <bean id="localFedoraServer" class="java.lang.String">
-        <constructor-arg value="${fedora.from.server:localhost:8080}" />
+        <constructor-arg value="localhost:8080" />
     </bean>
 
     <bean id="namespaceFile" class="java.io.File">
-        <constructor-arg type="java.lang.String" value="${migration.namespace.file:src/main/resources/namespaces.properties}"/>
+        <constructor-arg type="java.lang.String" value="src/main/resources/namespaces.properties"/>
     </bean>
 
     <bean id="propertiesFile" class="java.io.File">
-        <constructor-arg type="java.lang.String" value="${migration.mapping.file:src/test/resources/custom-mapping.properties}"/>
+        <constructor-arg type="java.lang.String" value="src/test/resources/custom-mapping.properties"/>
     </bean>
 
     <!-- SER foxml.export.dir OR CHANGE THIS TO THE DIRECTORY TO WHICH YOU EXPORTED "ARCHIVE" FOXML -->
     <bean id="exportDir" class="java.io.File">
-        <constructor-arg type="java.lang.String" value="${foxml.export.dir:src/test/resources/exported}" />
+        <constructor-arg type="java.lang.String" value="src/test/resources/exported" />
     </bean>
 
     <bean id="idIndex" class="java.io.File">

--- a/src/test/resources/spring/ocfl-user-it-setup.xml
+++ b/src/test/resources/spring/ocfl-user-it-setup.xml
@@ -1,51 +1,30 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!--
-  This configuration file serves as a starting point for a fedora 3 to fedora 4
-   migration when the fedora 3 content has been exported to "archive" FOXML 1.1
-   files.
-
-  There are several default values you will likely have to change below, each is
-  marked with a comment starting with "CHANGE THIS":
--->
-    <beans xmlns="http://www.springframework.org/schema/beans"
+<beans xmlns="http://www.springframework.org/schema/beans"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-       xmlns:context="http://www.springframework.org/schema/context"
-       xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-           http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-3.0.xsd">
+       xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd">
 
-    <context:property-placeholder/>
+    <!-- Main Migrator -->
 
     <bean id="migrator" class="org.fcrepo.migration.Migrator">
-        <property name="source" ref="${migration.layout:exported}" />
+        <property name="source" ref="exported" />
         <property name="handler" ref="objectAbstraction" />
-        <property name="limit" value="${migration.limit:2}" /><!-- SET migration.limit OR CHANGE THIS IF YOU WANT TO MIGRATE MORE THAN 2 OBJECTS -->
-        <!--PID List Managers help in selecting which source objects to migration, default is ALL-->
-        <property name="pidListManagers">
-            <list>
-                <bean class="org.fcrepo.migration.pidlist.UserProvidedPidListManager">
-                    <constructor-arg name="pidListFile" value="${migration.pid.list.file:#{null}}"/>
-                </bean>
-                <bean class="org.fcrepo.migration.pidlist.ResumePidListManager">
-                    <constructor-arg name="pidDir" value="${migration.pid.resume.dir:target/test/pid}"/>
-                    <constructor-arg name="acceptAll" value="${migration.pid.resume.all:true}"/>
-                </bean>
-            </list>
-        </property>
+        <property name="limit" value="-1" />
     </bean>
+
 
     <bean id="exported" class="org.fcrepo.migration.foxml.ArchiveExportedFoxmlDirectoryObjectSource" lazy-init="true">
         <constructor-arg name="exportDir" ref="exportDir" />
         <constructor-arg name="localFedoraServer" ref="localFedoraServer" />
         <property name="fetcher" ref="httpClientURLFetcher"/>
     </bean>
-    
+
     <bean id="legacy" class="org.fcrepo.migration.foxml.NativeFoxmlDirectoryObjectSource" lazy-init="true">
         <constructor-arg name="objectStore" ref="objectStore" />
         <constructor-arg name="resolver" ref="legacyIDResolver" />
         <constructor-arg name="localFedoraServer" ref="localFedoraServer" />
         <property name="fetcher" ref="httpClientURLFetcher"/>
     </bean>
-    
+
     <bean id="akubra" class="org.fcrepo.migration.foxml.NativeFoxmlDirectoryObjectSource" lazy-init="true">
         <constructor-arg name="objectStore" ref="objectStore" />
         <constructor-arg name="resolver" ref="akubraIDResolver" />
@@ -60,7 +39,7 @@
              the repository changes.  -->
         <!--  <constructor-arg name="indexDir" type="java.io.File" ref="indexRoot" /> -->
     </bean>
-    
+
     <bean id="akubraIDResolver" class="org.fcrepo.migration.foxml.AkubraFSIDResolver" lazy-init="true">
         <constructor-arg name="dsRoot" type="java.io.File" ref="datastreamStore"/>
         <!-- Add the following line back in if you wish to maintain a cache of the internal id mapping between
@@ -68,62 +47,40 @@
              the repository changes.  -->
         <!--<constructor-arg name="indexDir" type="java.io.File" ref="indexRoot" />-->
     </bean>
-    
-    
+
+
     <!-- Set foxml.dir.objects or CHANGE THIS TO YOUR FEDORA 3 OBJECTS DIRECTORY -->
     <bean id="objectStore" class="java.io.File">
-        <constructor-arg type="java.lang.String" value="${foxml.object.dir:src/test/resources/legacyFS/objects}" />
+        <constructor-arg type="java.lang.String" value="src/test/resources/legacyFS/objects" />
     </bean>
 
     <!-- Set foxml.store.datastreams or CHANGE THIS TO YOUR FEDORA 3 DATASTREAM DIRECTORY -->
     <bean id="datastreamStore" class="java.io.File">
-        <constructor-arg type="java.lang.String" value="${foxml.datastream.dir:src/test/resources/legacyFS/datastreams}" />
-    </bean>  
-    
+        <constructor-arg type="java.lang.String" value="src/test/resources/legacyFS/datastreams" />
+    </bean>
+
     <bean id="indexRoot" class="java.io.File">
-        <constructor-arg type="java.lang.String" value="${migration.index.root:index}" />
-    </bean>  
+        <constructor-arg type="java.lang.String" value="target/test/ocfl/user-it/index}" />
+    </bean>
 
     <bean id="objectAbstraction" class="org.fcrepo.migration.handlers.ObjectAbstractionStreamingFedoraObjectHandler">
         <constructor-arg ref="versionAbstraction"/>
     </bean>
 
     <bean id="versionAbstraction" class="org.fcrepo.migration.handlers.VersionAbstractionFedoraObjectHandler">
-        <constructor-arg ref="${migration.strategy:ldpFull}"/>
+        <constructor-arg ref="minimal"/>
     </bean>
-
-    <!-- Full LDP migration impl -->
-    <bean id="ldpFull" class="org.fcrepo.migration.handlers.BasicObjectVersionHandler">
-        <constructor-arg name="client" ref="${fedora.client:ocfl}" />
-        <constructor-arg name="idMapper" ref="idMapper" />
-        <constructor-arg name="localFedoraServer" ref="localFedoraServer" />
-        <constructor-arg name="namespacePrefixMapper" ref="namespacePrefixMapper"/>
-        <property name="customPropertyMapping" ref="propertiesFile" />
-        <property name="importExternal" value="${migration.import.external:false}" /><!-- CHANGE THIS IF YOU WANT TO IMPORT E DATASTREAMS -->
-        <property name="importRedirect" value="${migration.import.redirect:false}" /><!-- CHANGE THIS IF YOU WANT TO IMPORT R DATASTREAMS -->
-    </bean>
-
-    <!--
-       Mints a new fedora 4 path for each PID encountered during the migration.
-       The mappings are persisted in a lucene index configured in the "idIndex"
-       bean.  Furthermore, a file id-minter.log will contain the mapping as well.
-    -->
-    <bean id="idMapper" class="org.fcrepo.migration.idmappers.OpaqueIDMapper">
-        <constructor-arg name="cachedIDIndexDir" ref="idIndex" />
-        <constructor-arg name="f4Client" ref="${fedora.client:ocfl}" />
-    </bean>
-
 
     <bean id="namespacePrefixMapper" class="org.fcrepo.migration.foxml.NamespacePrefixMapper">
         <constructor-arg name="namespaceFile" type="java.io.File" ref="namespaceFile"/>
     </bean>
-    
+
     <bean id="minimal" class="org.fcrepo.migration.handlers.ocfl.ArchiveGroupHandler">
-    	<constructor-arg name="driver" ref="ocflDriver" />
+        <constructor-arg name="driver" ref="ocflDriver" />
     </bean>
-    
+
     <bean id="ocflDriver" class="org.fcrepo.migration.handlers.ocfl.HackyOcflDriver">
-        <constructor-arg ref="${fedora.client:ocfl}"/>
+        <constructor-arg ref="ocfl"/>
     </bean>
 
     <bean id="fedora4" class="org.fcrepo.migration.f4clients.StatelessFedora4Client">
@@ -132,10 +89,10 @@
         <!--<constructor-arg name="username" value="admin-username"/>-->
         <!--<constructor-arg name="password" value="admin-password"/>-->
     </bean>
-    
+
     <bean id="ocfl" class="org.fcrepo.migration.f4clients.OCFLFedora4Client" destroy-method="close">
-        <constructor-arg name="storage" value="${migration.ocfl.storage.dir:target/test/storage}"/>
-        <constructor-arg name="staging" value="${migration.ocfl.staging.dir:target/test/staging}"/>
+        <constructor-arg name="storage" value="target/test/ocfl/user-it/storage"/>
+        <constructor-arg name="staging" value="target/test/ocfl/user-it/staging"/>
         <constructor-arg name="mapper" value="FLAT"/>
     </bean>
 
@@ -143,25 +100,25 @@
 
     <!-- CHANGE THIS TO THE FEDORA 4 URL TO WHICH YOU WANT TO MIGRATE THE CONTENT -->
     <bean id="fedora4Url" class="java.lang.String">
-        <constructor-arg value="${fedora.to.baseuri:http://localhost:${fcrepo.dynamic.test.port:8080}/rest/}" />
+        <constructor-arg value="http://localhost:${fcrepo.dynamic.test.port:8080}/rest/" />
     </bean>
 
     <!-- The fedora 2 or 3 server migrated content is coming from -->
     <bean id="localFedoraServer" class="java.lang.String">
-        <constructor-arg value="${fedora.from.server:localhost:8080}" />
+        <constructor-arg value="localhost:8080" />
     </bean>
 
     <bean id="namespaceFile" class="java.io.File">
-        <constructor-arg type="java.lang.String" value="${migration.namespace.file:src/main/resources/namespaces.properties}"/>
+        <constructor-arg type="java.lang.String" value="src/main/resources/namespaces.properties"/>
     </bean>
 
     <bean id="propertiesFile" class="java.io.File">
-        <constructor-arg type="java.lang.String" value="${migration.mapping.file:src/test/resources/custom-mapping.properties}"/>
+        <constructor-arg type="java.lang.String" value="src/test/resources/custom-mapping.properties"/>
     </bean>
 
     <!-- SER foxml.export.dir OR CHANGE THIS TO THE DIRECTORY TO WHICH YOU EXPORTED "ARCHIVE" FOXML -->
     <bean id="exportDir" class="java.io.File">
-        <constructor-arg type="java.lang.String" value="${foxml.export.dir:src/test/resources/exported}" />
+        <constructor-arg type="java.lang.String" value="src/test/resources/exported" />
     </bean>
 
     <bean id="idIndex" class="java.io.File">


### PR DESCRIPTION
1. ResumePidList
   - Allows resuming the migration from the point of the last successfully migration F3 object
2. UserProvidedPidList
   - Allows for user to provide a list of PIDs to migrate

Resolves:
https://jira.duraspace.org/browse/FCREPO-3111 , and
https://jira.duraspace.org/browse/FCREPO-3112

# What's new?
Two new "PidListManagers" have been created. They can be configured in the spring.xml as follows:
```
    <bean id="migrator" class="org.fcrepo.migration.Migrator">
        <property name="source" ref="${migration.layout:exported}" />
        <property name="handler" ref="objectAbstraction" />
        <property name="limit" value="${migration.limit:2}" />
        <!--PID List Managers help in selecting which source objects to migration, default is ALL-->
        <property name="pidListManagers">
            <list>
                <bean class="org.fcrepo.migration.pidlist.UserProvidedPidListManager">
                    <constructor-arg name="pidListFile" value="${migration.pid.list.file:#{null}}"/>
                </bean>
                <bean class="org.fcrepo.migration.pidlist.ResumePidListManager">
                    <constructor-arg name="pidDir" value="${migration.pid.resume.dir:target/test/pid}"/>
                    <constructor-arg name="acceptAll" value="${migration.pid.resume.all:true}"/>
                </bean>
            </list>
        </property>
    </bean>
```
The idea is that these two "PidListManagers" will be executed in order, each being asked if they "accept" the provided PID. If either of the managers do not "accept" the PID, the PID will not be processed.
The `UserProvidedPidListManager` takes a file of line-separated PIDs to process. If no file is provided, all PIDs are accepted.
The `ResumePidListManager` keeps track of the PID and index of the last processed object. If `acceptAll` is true, this state of "last processed object" is maintained, but all PIDs are "accepted". However, if `acceptAll` is false, any PIDs that come before the PID/index found in the state file, will not be processed. Note, this assumes a deterministic, repeatable order of source PIDs.

# How should this be tested?
Besides the unit and integration tests provided in this pull-request, testing should involve:
- Configuring the spring.xml with one, both or none of the "PidListManagers"
- Run, kill and re-run the tool, to test the "resume" functionality
- Create a pid-list to test the pid-list functionality

# Interested parties
@fcrepo4/committers
