### PR TITLE
Add support for PAIRTREE and TRUNCATED storage layouts

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ The system properties determine the specific details of the migration, and are d
 * `migration.namespace.file`.  RDF namespace file.  Default  ***`src/main/resources/namespaces.properties`***
 * `migration.ocfl.storage.dir`.  Path to OCFL storage dir.  Only relevant when `fedora.client` is `ocfl`.  Default ***`target/test/ocfl`***
 * `migration.ocfl.staging.dir`.  Path to OCFL staging dir.  Only relevant when `fedora.client` is `ocfl`. Default ***`target/test/staging`***
+* `migration.ocfl.layout`.  Storage layout approach. Options include FLAT, PAIRTREE, and TRUNCATED. Only relevant when `fedora.client` is `ocfl`. Default ***`FLAT`***
 * `migration.pid.list.file`.  File containing list of PIDs to migrate.  Only relevant when `fedora.client` is `ocfl`. Default ***`null`***
 * `migration.pid.resume.dir`.  Path to directory in which a "resume file" will be created/used in the case that a previous run must be resumed from the last exported PID/Object.  Only relevant when `fedora.client` is `ocfl`. Default ***`target/test/pid`***
 * `migration.pid.resume.all`.  Boolean flag indicating whether the current execution should resume from the last exported PID/Object of process from the beginning.  Only relevant when `fedora.client` is `ocfl`. Default ***`true`***

--- a/conf/fedora3.xml
+++ b/conf/fedora3.xml
@@ -136,7 +136,7 @@
     <bean id="ocfl" class="org.fcrepo.migration.f4clients.OCFLFedora4Client" destroy-method="close">
         <constructor-arg name="storage" value="${migration.ocfl.storage.dir:target/test/storage}"/>
         <constructor-arg name="staging" value="${migration.ocfl.staging.dir:target/test/staging}"/>
-        <constructor-arg name="mapper" value="FLAT"/>
+        <constructor-arg name="mapper" value="${migration.ocfl.layout:FLAT}"/>
     </bean>
 
     <bean id="httpClientURLFetcher" class="org.fcrepo.migration.foxml.HttpClientURLFetcher" />

--- a/src/main/java/org/fcrepo/migration/f4clients/OCFLFedora4Client.java
+++ b/src/main/java/org/fcrepo/migration/f4clients/OCFLFedora4Client.java
@@ -41,7 +41,7 @@ public class OCFLFedora4Client implements Fedora4Client {
     private final String stagingRoot;
 
     public enum ObjectIdMapperType {
-        FLAT
+        FLAT, PAIRTREE, TRUNCATED
     }
 
     /**
@@ -58,13 +58,20 @@ public class OCFLFedora4Client implements Fedora4Client {
         this.storageRoot = storage;
         this.stagingRoot = staging;
 
-        ObjectIdPathMapper objectIdPathMapper = null;
+        ObjectIdPathMapper objectIdPathMapper;
+        final ObjectIdPathMapperBuilder builder = new ObjectIdPathMapperBuilder().withDefaultCaffeineCache();
         switch (mapper) {
         case FLAT:
-            objectIdPathMapper = new ObjectIdPathMapperBuilder().withDefaultCaffeineCache().buildFlatMapper();
+            objectIdPathMapper = builder.buildFlatMapper();
+            break;
+        case PAIRTREE:
+            objectIdPathMapper = builder.buildDefaultPairTreeMapper();
+            break;
+        case TRUNCATED:
+            objectIdPathMapper = builder.buildDefaultTruncatedHashMapper();
             break;
         default:
-            throw new RuntimeException("No implementation for the maper: " + mapper);
+            throw new RuntimeException("No implementation for the mapper: " + mapper);
         }
 
         // Create storage dir if does not exist


### PR DESCRIPTION
Resolves: https://jira.duraspace.org/browse/FCREPO-3110

This PR adds support for PAIRTREE and TRUNCATED storage layouts

# How should this be tested?
After building the project, run a local migration three times, using each of the three options:
```
java -Dmigration.ocfl.layout=FLAT
```
```
java -Dmigration.ocfl.layout=PAIRTREE
```
```
java -Dmigration.ocfl.layout=TRUNCATED
```
If no option is provided, the default layout should be `FLAT`

# Interested parties
@fcrepo4/committers and @pwinckles 
