### PR TITLE
MOVE staged content into OCFL

### DIFF
--- a/src/main/java/org/fcrepo/migration/f4clients/OCFLFedora4Client.java
+++ b/src/main/java/org/fcrepo/migration/f4clients/OCFLFedora4Client.java
@@ -12,6 +12,7 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.UUID;
 
+import edu.wisc.library.ocfl.api.OcflOption;
 import edu.wisc.library.ocfl.api.model.ObjectVersionId;
 import org.apache.commons.io.IOUtils;
 import org.fcrepo.migration.Fedora4Client;
@@ -210,7 +211,8 @@ public class OCFLFedora4Client implements Fedora4Client {
         final File stagingObject = new File(stagingRoot, ocflObject);
         final User user = new User().setName("name").setAddress("address");
         final CommitInfo defaultCommitInfo = new CommitInfo().setMessage("message").setUser(user);
-        ocflRepo.putObject(ObjectVersionId.head(ocflObject), stagingObject.toPath(), defaultCommitInfo);
+        ocflRepo.putObject(ObjectVersionId.head(ocflObject), stagingObject.toPath(), defaultCommitInfo,
+                OcflOption.MOVE_SOURCE);
     }
 
     /**


### PR DESCRIPTION
Resolves: https://jira.lyrasis.org/browse/FCREPO-3133

The `staging` directory is already removed when the tool terminates. The only difference this update makes is to `move` the staged content during the migration.