### PR TITLE
Enable debug logging only when debug flag set

### DIFF
--- a/src/main/java/org/fcrepo/migration/PicocliMigrator.java
+++ b/src/main/java/org/fcrepo/migration/PicocliMigrator.java
@@ -25,6 +25,8 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.Callable;
 
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.LoggerContext;
 import org.apache.commons.io.FileUtils;
 import org.fcrepo.migration.f4clients.OCFLFedora4Client;
 import org.fcrepo.migration.f4clients.OCFLFedora4Client.ObjectIdMapperType;
@@ -43,6 +45,7 @@ import org.fcrepo.migration.pidlist.ResumePidListManager;
 import org.fcrepo.migration.pidlist.UserProvidedPidListManager;
 import org.slf4j.Logger;
 
+import org.slf4j.LoggerFactory;
 import picocli.CommandLine;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.Option;
@@ -149,8 +152,19 @@ public class PicocliMigrator implements Callable<Integer> {
         }
     }
 
+    private static void setDebugLogLevel() {
+        final LoggerContext loggerContext = (LoggerContext) LoggerFactory.getILoggerFactory();
+        final ch.qos.logback.classic.Logger logger = loggerContext.getLogger("org.fcrepo.migration");
+        logger.setLevel(Level.toLevel("DEBUG"));
+    }
+
     @Override
     public Integer call() throws Exception {
+
+        // Set debug log level if requested
+        if (debug) {
+            setDebugLogLevel();
+        }
 
         // Pre-processing directory verification
         notNull(targetDir, "targetDir must be provided!");

--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -24,7 +24,7 @@
         <appender-ref ref="IDFILE"/>
     </logger>
 
-    <logger name="org.fcrepo.migration" additivity="false" level="DEBUG">
+    <logger name="org.fcrepo.migration" additivity="false" level="INFO">
         <appender-ref ref="STDOUT"/>
     </logger>
 


### PR DESCRIPTION
**JIRA Ticket**: https://jira.lyrasis.org/browse/FCREPO-3144

# What does this Pull Request do?
* Set default `org.fcrepo.migration` package log level to INFO (changed from DEBUG)
* Set `org.fcrepo.migration` package log level to DEBUG when debug flag is set

# What's new?

New method in PicocliMigrator class: `setDebugLogLevel()`, called at beginning of execution

# How should this be tested?

* Run the migration utility without the 'debug' flag:  only INFO and above messages should be shown on STDOUT
* Run the migration utility with the 'debug' flag:  DEBUG messages should be shown for all classes in the `org.fcrepo.migration` package.

# Additional Notes:

This implementation of debug logging is not ideal, as the setDebugLogLevel() method explicitly calls the Logback logging class (`ch.qos.logback.classic.Logger`) to set the log level, thereby bypassing the benefits of using the slf4j abstract logging utility.  This approach is necessary, as sl4fj itself does not have a way to set the log level for a package at runtime. However, as Logback is only explicitly called in the PicocliMigrator class (the main class), I think the benefits of this approach outweigh the downsides.  It will only potentially be an issue if the logback logging tool is replaced with something else.

# Interested parties
@awoods
