### PR TITLE
Use migrated versionId of 'ignored' for OCFL

### DIFF
--- a/src/main/java/org/fcrepo/migration/handlers/ocfl/HackyOcflDriver.java
+++ b/src/main/java/org/fcrepo/migration/handlers/ocfl/HackyOcflDriver.java
@@ -53,17 +53,17 @@ implements OcflDriver {
 
                 // We exploit knowledge that client chops up the given path into ocfl object id
                 // path via the "/" separator. ContentType is unused by the OCFL Fedora4Client
-                // impls.
+                // impls, so we use the least-specific mime type
                 client.createOrUpdateNonRDFResource(id + "/" + path,
                                                     content,
-                        "foo/dontCare");
+                        "application/octet-stream");
             }
 
             @Override
             public void commit() {
 
                 // versionID is unused by the OCFL Fedora4Client impls
-                client.createVersionSnapshot(id, "foo");
+                client.createVersionSnapshot(id, "ignored");
             }
         };
     }


### PR DESCRIPTION
**JIRA Ticket**: https://jira.lyrasis.org/browse/FCREPO-3147

# What does this Pull Request do?
* Use and log OCFL versionId value of 'ignored', to indicate that legacy versionIds are not migrated to OCFL objects.
* Use content-type of `application/octet-stream` (the least specific mime type) as contentType argument to OCFL client nonRDF resource create/update method, as contentType is not used by the OCFL client.

# How should this be tested?
Run the migration-utils migration to OCFL.  The INFO level log output should show a versionId of 'ignored' for migrated object versions.  There should be no other change to migrated content.

# Interested parties
@awoods 
