### PR TITLE
Add option for user-provided indexDir

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ General usage of the migration utils CLI is as follows:
 The following CLI options for specifying details of a given migration are available:
 ```
 Usage: migration-utils [-hrV] [--debug] -a=<targetDir> [-d=<f3DatastreamsDir>]
-                       [-e=<f3ExportedDir>] [-l=<objectLimit>]
+                       [-e=<f3ExportedDir>] [-i=<indexDir>] [-l=<objectLimit>]
                        [-o=<f3ObjectsDir>] [-p=<pidFile>] -t=<f3SourceType>
                        [-y=<ocflLayout>]
   -h, --help                 Show this help message and exit.
@@ -79,6 +79,8 @@ Usage: migration-utils [-hrV] [--debug] -a=<targetDir> [-d=<f3DatastreamsDir>]
                                object
                                Default: false
   -p, --pid-file=<pidFile>   PID file listing which Fedora 3 objects to migrate
+  -i, --index-dir=<indexDir> Directory where cached index of datastreams (will
+                               reuse index if already exists)
       --debug                Enables debug logging
 ```
 

--- a/src/main/java/org/fcrepo/migration/PicocliMigrator.java
+++ b/src/main/java/org/fcrepo/migration/PicocliMigrator.java
@@ -113,6 +113,10 @@ public class PicocliMigrator implements Callable<Integer> {
             description = "PID file listing which Fedora 3 objects to migrate")
     private File pidFile;
 
+    @Option(names = {"--index-dir", "-i"}, order = 24,
+            description = "Directory where cached index of datastreams (will reuse index if already exists)")
+    private File indexDir;
+
     @Option(names = {"--debug"}, order = 30, description = "Enables debug logging")
     private boolean debug;
 
@@ -208,7 +212,7 @@ public class PicocliMigrator implements Callable<Integer> {
                 expressionTrue(f3ObjectsDir.exists(), f3ObjectsDir, "f3ObjectsDir must exist! " +
                         f3ObjectsDir.getAbsolutePath());
 
-                idResolver = new AkubraFSIDResolver(f3DatastreamsDir);
+                idResolver = new AkubraFSIDResolver(indexDir, f3DatastreamsDir);
                 objectSource = new NativeFoxmlDirectoryObjectSource(f3ObjectsDir, idResolver, localFedoraServer);
                 break;
             case LEGACY:
@@ -217,7 +221,7 @@ public class PicocliMigrator implements Callable<Integer> {
                 expressionTrue(f3ObjectsDir.exists(), f3ObjectsDir, "f3ObjectsDir must exist! " +
                         f3ObjectsDir.getAbsolutePath());
 
-                idResolver = new LegacyFSIDResolver(f3DatastreamsDir);
+                idResolver = new LegacyFSIDResolver(indexDir, f3DatastreamsDir);
                 objectSource = new NativeFoxmlDirectoryObjectSource(f3ObjectsDir, idResolver, localFedoraServer);
                 break;
             default:

--- a/src/main/java/org/fcrepo/migration/foxml/DirectoryScanningIDResolver.java
+++ b/src/main/java/org/fcrepo/migration/foxml/DirectoryScanningIDResolver.java
@@ -102,7 +102,7 @@ public abstract class DirectoryScanningIDResolver implements InternalIDResolver 
             iwc.setOpenMode(IndexWriterConfig.OpenMode.CREATE);
             final Directory dir = FSDirectory.open(indexDir.toPath());
             final IndexWriter writer = new IndexWriter(dir, iwc);
-            LOGGER.info("Builidng an index of all the datastreams in \"" + dsRoot.getPath() + "\"...");
+            LOGGER.info("Building an index of all the datastreams in \"" + dsRoot.getPath() + "\"...");
             indexDatastreams(writer, dsRoot);
 
             writer.commit();


### PR DESCRIPTION
Resolves: https://jira.lyrasis.org/browse/FCREPO-3149

# What does this Pull Request do?
The tool will create an index at the user-provided location if it does not already exist, and use the index if it does exist.

# How should this be tested?
1. Run the tool without the `-i` option
   - Should run as before (creates temp index, deletes index after tool terminates)
1. Run the tool with `-i` option, pointing to non-existent directory
   - Index should be created at user-provided location, persisting after run completes
1. Run the tool with `-i` option, pointing to directory created in previous step
   - Index should be used at user-provided location, persisting after run completes
   - Check that timestamps have not been updated on files in index directory

# Interested parties
@sprater
