### PR TITLE
Correct OCFL imports

### DIFF
--- a/src/main/java/org/fcrepo/migration/f4clients/OCFLFedora4Client.java
+++ b/src/main/java/org/fcrepo/migration/f4clients/OCFLFedora4Client.java
@@ -20,7 +20,7 @@ import edu.wisc.library.ocfl.api.model.User;
 import edu.wisc.library.ocfl.core.OcflRepositoryBuilder;
 import edu.wisc.library.ocfl.core.extension.layout.config.DefaultLayoutConfig;
 import edu.wisc.library.ocfl.core.extension.layout.config.LayoutConfig;
-import edu.wisc.library.ocfl.core.storage.FileSystemOcflStorage;
+import edu.wisc.library.ocfl.core.storage.filesystem.FileSystemOcflStorage;
 import org.apache.commons.io.IOUtils;
 import org.fcrepo.migration.Fedora4Client;
 import org.slf4j.Logger;


### PR DESCRIPTION
**JIRA Ticket**: n/a

# What does this Pull Request do?
Correct the import packages to align with changes in the ocfl-java client code.

# How should this be tested?

Before PR, build fails
```
[INFO] -------------------------------------------------------------
[ERROR] COMPILATION ERROR : 
[INFO] -------------------------------------------------------------
[ERROR] /sw/var/www/fcrepo4/migration-utils/src/main/java/org/fcrepo/migration/f4clients/OCFLFedora4Client.java:[23,42] cannot find symbol
  symbol:   class FileSystemOcflStorage
  location: package edu.wisc.library.ocfl.core.storage
[ERROR] /sw/var/www/fcrepo4/migration-utils/src/main/java/org/fcrepo/migration/f4clients/OCFLFedora4Client.java:[94,24] cannot find symbol
  symbol:   variable FileSystemOcflStorage
  location: class org.fcrepo.migration.f4clients.OCFLFedora4Client
[INFO] 2 errors 
[INFO] -------------------------------------------------------------
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  10.566 s
[INFO] Finished at: 2020-01-17T07:31:43-06:00
[INFO] ------------------------------------------------------------------------
```

After PR, build succeeds.

# Interested parties
@fcrepo4-exts/committers and @tomcbe
