### PR TITLE
Ensure ID index dir is non-empty before assuming it contains index files

### DIFF
--- a/src/main/java/org/fcrepo/migration/foxml/DirectoryScanningIDResolver.java
+++ b/src/main/java/org/fcrepo/migration/foxml/DirectoryScanningIDResolver.java
@@ -93,7 +93,8 @@ public abstract class DirectoryScanningIDResolver implements InternalIDResolver 
             indexDir = cachedIndexDir;
         }
 
-        if (indexDir.exists()) {
+        // Index dir exists and is non-empty
+        if (indexDir.exists() && indexDir.list().length > 0) {
             LOGGER.warn("Index exists at \"" + indexDir.getPath() + "\" and will be used.  "
                     + "To clear index, simply delete this directory and re-run the application.");
         } else {

--- a/src/test/java/org/fcrepo/migration/foxml/AkubraFSIDResolverIT.java
+++ b/src/test/java/org/fcrepo/migration/foxml/AkubraFSIDResolverIT.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2015 DuraSpace, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.fcrepo.migration.foxml;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.slf4j.Logger;
+
+import java.io.File;
+import java.io.IOException;
+import static org.slf4j.LoggerFactory.getLogger;
+
+/**
+ * @author awoods
+ * @since 2020-01-27
+ */
+public class AkubraFSIDResolverIT {
+
+    final static Logger LOGGER = getLogger(AkubraFSIDResolverIT.class);
+
+    private static AkubraFSIDResolver resolver;
+
+    @Test
+    public void testWithEmptyIndexDir() throws IOException {
+
+        final File testDir = new File("target/test/akubra");
+        testDir.mkdirs();
+
+        // Create empty dir
+        final File indexDir = new File(testDir, "index");
+        indexDir.mkdirs();
+
+        final File dsRoot = new File("src/test/resources/akubraFS");
+
+        resolver = new AkubraFSIDResolver(indexDir, dsRoot);
+
+        final File[] files = indexDir.listFiles();
+        Assert.assertTrue("There should be index files in the previously empty dir", files.length > 0);
+    }
+
+}


### PR DESCRIPTION
Resolves: https://jira.lyrasis.org/browse/FCREPO-3185

# What does this Pull Request do?
Adds a check to ensure that user-provided index-dir is non-empty before assuming it contains index files.

# How should this be tested?
1. New integration test should pass during build
1. Also, create an empty directory
   - Run migration utils with arg `-i path/to/empty/dir`
   - Tool should create index files within the previously empty dir.

# Interested parties
@fcrepo4/committers
