### PR TITLE
Add option for migrated datastreams to have file extensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ General usage of the migration utils CLI is as follows:
 
 The following CLI options for specifying details of a given migration are available:
 ```
-Usage: migration-utils [-hrV] [--debug] -a=<targetDir> [-d=<f3DatastreamsDir>]
+Usage: migration-utils [-hrVx] [--debug] -a=<targetDir> [-d=<f3DatastreamsDir>]
                        [-e=<f3ExportedDir>] [-i=<indexDir>] [-l=<objectLimit>]
                        [-o=<f3ObjectsDir>] [-p=<pidFile>] -t=<f3SourceType>
                        [-y=<ocflLayout>]
@@ -81,6 +81,9 @@ Usage: migration-utils [-hrV] [--debug] -a=<targetDir> [-d=<f3DatastreamsDir>]
   -p, --pid-file=<pidFile>   PID file listing which Fedora 3 objects to migrate
   -i, --index-dir=<indexDir> Directory where cached index of datastreams (will
                                reuse index if already exists)
+  -x, --extensions           Add file extensions to migrated datastreams based
+                               on mimetype recorded in FOXML
+                               Default: false
       --debug                Enables debug logging
 ```
 

--- a/conf/fedora3.xml
+++ b/conf/fedora3.xml
@@ -120,6 +120,7 @@
     
     <bean id="minimal" class="org.fcrepo.migration.handlers.ocfl.ArchiveGroupHandler">
     	<constructor-arg name="driver" ref="ocflDriver" />
+      <constructor-arg name="addDatastreamExtensions" value="false" />
     </bean>
     
     <bean id="ocflDriver" class="org.fcrepo.migration.handlers.ocfl.HackyOcflDriver">

--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
     <jena.version>2.12.1</jena.version>
     <checkstyle.plugin.version>2.15</checkstyle.plugin.version>
     <logback.version>1.1.2</logback.version>
-    <mockito.version>1.10.8</mockito.version>
+    <mockito.version>2.22.0</mockito.version>
     <slf4j.version>1.7.10</slf4j.version>
     <junit.version>4.11</junit.version>
     <fcrepo-build-tools.version>4.3.0</fcrepo-build-tools.version>
@@ -128,6 +128,11 @@
       <groupId>org.apache.lucene</groupId>
       <artifactId>lucene-analyzers-common</artifactId>
       <version>${lucene.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.tika</groupId>
+      <artifactId>tika-core</artifactId>
+      <version>1.23</version>
     </dependency>
     <dependency>
       <groupId>org.springframework</groupId>

--- a/src/main/java/org/fcrepo/migration/PicocliMigrator.java
+++ b/src/main/java/org/fcrepo/migration/PicocliMigrator.java
@@ -117,6 +117,10 @@ public class PicocliMigrator implements Callable<Integer> {
             description = "Directory where cached index of datastreams (will reuse index if already exists)")
     private File indexDir;
 
+    @Option(names = {"--extensions", "-x"}, defaultValue = "false", showDefaultValue = ALWAYS, order = 25,
+            description = "Add file extensions to migrated datastreams based on mimetype recorded in FOXML")
+    private boolean addExtensions;
+
     @Option(names = {"--debug"}, order = 30, description = "Enables debug logging")
     private boolean debug;
 
@@ -234,7 +238,7 @@ public class PicocliMigrator implements Callable<Integer> {
                 ocflStagingDir.getAbsolutePath(),
                 ocflLayout);
         final OcflDriver ocflDriver = new HackyOcflDriver(fedora4Client);
-        final FedoraObjectVersionHandler archiveGroupHandler = new ArchiveGroupHandler(ocflDriver);
+        final FedoraObjectVersionHandler archiveGroupHandler = new ArchiveGroupHandler(ocflDriver, addExtensions);
         final FedoraObjectHandler versionHandler = new VersionAbstractionFedoraObjectHandler(archiveGroupHandler);
         final StreamingFedoraObjectHandler objectHandler = new ObjectAbstractionStreamingFedoraObjectHandler(
                 versionHandler);

--- a/src/test/java/org/fcrepo/migration/foxml/FoxmlDirectoryDFSIteratorTest.java
+++ b/src/test/java/org/fcrepo/migration/foxml/FoxmlDirectoryDFSIteratorTest.java
@@ -38,17 +38,11 @@ public class FoxmlDirectoryDFSIteratorTest {
 
     @Mock private File f1;
 
-    @Mock private File f2;
-
     @Before
     public void setup() {
-        Mockito.when(root.isFile()).thenReturn(false);
-        Mockito.when(root.isDirectory()).thenReturn(true);
-        Mockito.when(root.getName()).thenReturn("root");
         Mockito.when(root.listFiles()).thenReturn(new File[] { f1 });
 
         Mockito.when(f1.isFile()).thenReturn(true);
-        Mockito.when(f1.isDirectory()).thenReturn(false);
         Mockito.when(f1.getName()).thenReturn(".hidden");
 
     }

--- a/src/test/java/org/fcrepo/migration/handlers/ocfl/ArchiveGroupHandlerTest.java
+++ b/src/test/java/org/fcrepo/migration/handlers/ocfl/ArchiveGroupHandlerTest.java
@@ -1,0 +1,234 @@
+/**
+ * Copyright 2015 DuraSpace, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.fcrepo.migration.handlers.ocfl;
+
+import org.fcrepo.migration.ContentDigest;
+import org.fcrepo.migration.DatastreamInfo;
+import org.fcrepo.migration.DatastreamVersion;
+import org.fcrepo.migration.ObjectInfo;
+import org.fcrepo.migration.ObjectProperties;
+import org.fcrepo.migration.ObjectReference;
+import org.fcrepo.migration.ObjectVersionReference;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.List;
+
+import static java.util.Arrays.asList;
+import static java.util.Collections.singletonList;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Unit tests for the ArchiveGroupHandler
+ *
+ * @author awoods
+ * @since 2020-01-29
+ */
+@RunWith(MockitoJUnitRunner.Strict.class)
+public class ArchiveGroupHandlerTest {
+
+    private ArchiveGroupHandler handler;
+
+    @Mock private OcflDriver ocflDriver;
+    @Mock private OcflSession ocflSession;
+
+    @Captor private ArgumentCaptor<String> filenameCaptor;
+
+
+    @Before
+    public void setup() {
+        when(ocflDriver.Open(Mockito.anyString())).thenReturn(ocflSession);
+    }
+
+    @Test
+    public void testDatastreamExtensions() {
+        final boolean addDatastreamExtensions = true;
+
+        handler = new ArchiveGroupHandler(ocflDriver, addDatastreamExtensions);
+
+        handler.processObjectVersions(singletonList(createObjectVersionReference()));
+
+        verify(ocflSession, times(6)).put(filenameCaptor.capture(), any(InputStream.class));
+
+        final List<String> filenames = filenameCaptor.getAllValues();
+
+        // With three datastream versions, 'put' should be called six times
+        Assert.assertEquals(6, filenames.size());
+
+        // Three 'put' calls writing metadata
+        Assert.assertTrue(listAsString(filenames), filenames.remove("dsid.nt"));
+        Assert.assertTrue(listAsString(filenames), filenames.remove("dsid.nt"));
+        Assert.assertTrue(listAsString(filenames), filenames.remove("dsid.nt"));
+
+        // One call for each of the mimetypes: text, rdf, jpg
+        Assert.assertTrue(listAsString(filenames), filenames.contains("dsid.txt"));
+        Assert.assertTrue(listAsString(filenames), filenames.contains("dsid.rdf"));
+        Assert.assertTrue(listAsString(filenames), filenames.contains("dsid.jpg"));
+
+    }
+
+    private String listAsString(final List<String> filenames) {
+        final StringBuilder sb = new StringBuilder();
+        filenames.forEach(f -> sb.append(f).append(", "));
+        sb.delete(sb.length() - 2, sb.length());
+        return sb.toString();
+    }
+
+    // Mock classes below -------------------------------------
+
+    @Mock private ObjectInfo objectInfo0;
+    private ObjectVersionReference createObjectVersionReference() {
+        return new ObjectVersionReference() {
+            @Override
+            public ObjectReference getObject() {
+                return null;
+            }
+
+            @Override
+            public ObjectInfo getObjectInfo() {
+                when(objectInfo0.getPid()).thenReturn("pid");
+                return objectInfo0;
+            }
+
+            @Override
+            public ObjectProperties getObjectProperties() {
+                return null;
+            }
+
+            @Override
+            public String getVersionDate() {
+                return null;
+            }
+
+            @Override
+            public List<DatastreamVersion> listChangedDatastreams() {
+                return asList(createDatastreamVersion("text/plain"),
+                        createDatastreamVersion("application/rdf+xml"),
+                        createDatastreamVersion("image/jpeg"));
+            }
+
+            @Override
+            public boolean isLastVersion() {
+                return false;
+            }
+
+            @Override
+            public boolean isFirstVersion() {
+                return false;
+            }
+
+            @Override
+            public int getVersionIndex() {
+                return 0;
+            }
+
+            @Override
+            public boolean wasDatastreamChanged(final String dsId) {
+                return false;
+            }
+        };
+    }
+
+    @Mock DatastreamInfo datastreamInfo;
+    @Mock ObjectInfo objectInfo1;
+    private DatastreamVersion createDatastreamVersion(final String mimeType) {
+
+        return new DatastreamVersion() {
+            @Override
+            public DatastreamInfo getDatastreamInfo() {
+                when(datastreamInfo.getControlGroup()).thenReturn("M");
+                when(datastreamInfo.getObjectInfo()).thenReturn(objectInfo1);
+                when(datastreamInfo.getDatastreamId()).thenReturn("dsid");
+                when(objectInfo1.getPid()).thenReturn("pid");
+                return datastreamInfo;
+            }
+
+            @Override
+            public String getVersionId() {
+                return null;
+            }
+
+            @Override
+            public String getMimeType() {
+                return mimeType;
+            }
+
+            @Override
+            public String getLabel() {
+                return null;
+            }
+
+            @Override
+            public String getCreated() {
+                return null;
+            }
+
+            @Override
+            public String getAltIds() {
+                return null;
+            }
+
+            @Override
+            public String getFormatUri() {
+                return null;
+            }
+
+            @Override
+            public long getSize() {
+                return 0;
+            }
+
+            @Override
+            public ContentDigest getContentDigest() {
+                return null;
+            }
+
+            @Override
+            public InputStream getContent() throws IOException {
+                return InputStream.nullInputStream();
+            }
+
+            @Override
+            public String getExternalOrRedirectURL() {
+                return "external-url";
+            }
+
+            @Override
+            public boolean isFirstVersionIn(final ObjectReference obj) {
+                return false;
+            }
+
+            @Override
+            public boolean isLastVersionIn(final ObjectReference obj) {
+                return false;
+            }
+        };
+    }
+
+}

--- a/src/test/resources/spring/ocfl-pid-it-setup.xml
+++ b/src/test/resources/spring/ocfl-pid-it-setup.xml
@@ -77,6 +77,7 @@
 
     <bean id="minimal" class="org.fcrepo.migration.handlers.ocfl.ArchiveGroupHandler">
         <constructor-arg name="driver" ref="ocflDriver" />
+        <constructor-arg name="addDatastreamExtensions" value="false" />
     </bean>
 
     <bean id="ocflDriver" class="org.fcrepo.migration.handlers.ocfl.HackyOcflDriver">

--- a/src/test/resources/spring/ocfl-user-it-setup.xml
+++ b/src/test/resources/spring/ocfl-user-it-setup.xml
@@ -77,6 +77,7 @@
 
     <bean id="minimal" class="org.fcrepo.migration.handlers.ocfl.ArchiveGroupHandler">
         <constructor-arg name="driver" ref="ocflDriver" />
+        <constructor-arg name="addDatastreamExtensions" value="false" />
     </bean>
 
     <bean id="ocflDriver" class="org.fcrepo.migration.handlers.ocfl.HackyOcflDriver">


### PR DESCRIPTION
Update mockito dependency
Add additional parameter to 'ArchiveGroupHandler'
  - and update spring.xml files accordingly
Add Tika dependency for mimetype to extension mapping
Add ArchiveGroupHandlerTest unit test
Add commandline argument for enabling addition of file extensions
Update README with new commandline argument

Resolves: https://jira.lyrasis.org/browse/FCREPO-3181

# How should this be tested?
The basic idea is that you want to run two migrations, one with the `--extensions` option, and one without... then verify that the migrated datastreams do or do not have file extensions.

1. Verify migrated datastreams have file extensions
```
java -jar target/migration-utils-4.4.1-SNAPSHOT-driver.jar [options] -x
```
2. Verify migrated datastreams do not have file extensions (notice, no `-x` option)
```
java -jar target/migration-utils-4.4.1-SNAPSHOT-driver.jar [options]
```

# Interested parties
@sprater 
