### PR TITLE
Add user option for specifying F3 hostname

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,5 @@ exported-id-index/
 .classpath
 .project
 .settings
+
+pids.txt

--- a/README.md
+++ b/README.md
@@ -50,9 +50,9 @@ General usage of the migration utils CLI is as follows:
 The following CLI options for specifying details of a given migration are available:
 ```
 Usage: migration-utils [-hrVx] [--debug] -a=<targetDir> [-d=<f3DatastreamsDir>]
-                       [-e=<f3ExportedDir>] [-i=<indexDir>] [-l=<objectLimit>]
-                       [-o=<f3ObjectsDir>] [-p=<pidFile>] -t=<f3SourceType>
-                       [-y=<ocflLayout>]
+                       [-e=<f3ExportedDir>] [-f=<f3hostname>] [-i=<indexDir>]
+                       [-l=<objectLimit>] [-o=<f3ObjectsDir>] [-p=<pidFile>]
+                       -t=<f3SourceType> [-y=<ocflLayout>]
   -h, --help                 Show this help message and exit.
   -V, --version              Print version information and exit.
   -t, --source-type=<f3SourceType>
@@ -84,6 +84,10 @@ Usage: migration-utils [-hrVx] [--debug] -a=<targetDir> [-d=<f3DatastreamsDir>]
   -x, --extensions           Add file extensions to migrated datastreams based
                                on mimetype recorded in FOXML
                                Default: false
+  -f, --f3hostname=<f3hostname>
+                             Hostname of Fedora 3, used for replacing
+                               placeholder in 'E' and 'R' datastream URLs
+                               Default: fedora.info
       --debug                Enables debug logging
 ```
 

--- a/src/main/java/org/fcrepo/migration/PicocliMigrator.java
+++ b/src/main/java/org/fcrepo/migration/PicocliMigrator.java
@@ -121,6 +121,10 @@ public class PicocliMigrator implements Callable<Integer> {
             description = "Add file extensions to migrated datastreams based on mimetype recorded in FOXML")
     private boolean addExtensions;
 
+    @Option(names = {"--f3hostname", "-f"}, defaultValue = "fedora.info", showDefaultValue = ALWAYS, order = 26,
+            description = "Hostname of Fedora 3, used for replacing placeholder in 'E' and 'R' datastream URLs")
+    private String f3hostname;
+
     @Option(names = {"--debug"}, order = 30, description = "Enables debug logging")
     private boolean debug;
 
@@ -198,9 +202,6 @@ public class PicocliMigrator implements Callable<Integer> {
             pidDir.mkdirs();
         }
 
-        // Default "local Fedora server" URI... can expose as user-option in the future
-        final String localFedoraServer = "fedora.info";
-
         // Which F3 source are we using? - verify associated options
         ObjectSource objectSource;
         InternalIDResolver idResolver;
@@ -208,7 +209,7 @@ public class PicocliMigrator implements Callable<Integer> {
             case EXPORTED:
                 notNull(f3ExportedDir, "f3ExportDir must be used with 'exported' source!");
 
-                objectSource = new ArchiveExportedFoxmlDirectoryObjectSource(f3ExportedDir, localFedoraServer);
+                objectSource = new ArchiveExportedFoxmlDirectoryObjectSource(f3ExportedDir, f3hostname);
                 break;
             case AKUBRA:
                 notNull(f3DatastreamsDir, "f3DatastreamsDir must be used with 'akubra' or 'legacy' source!");
@@ -217,7 +218,7 @@ public class PicocliMigrator implements Callable<Integer> {
                         f3ObjectsDir.getAbsolutePath());
 
                 idResolver = new AkubraFSIDResolver(indexDir, f3DatastreamsDir);
-                objectSource = new NativeFoxmlDirectoryObjectSource(f3ObjectsDir, idResolver, localFedoraServer);
+                objectSource = new NativeFoxmlDirectoryObjectSource(f3ObjectsDir, idResolver, f3hostname);
                 break;
             case LEGACY:
                 notNull(f3DatastreamsDir, "f3DatastreamsDir must be used with 'akubra' or 'legacy' source!");
@@ -226,7 +227,7 @@ public class PicocliMigrator implements Callable<Integer> {
                         f3ObjectsDir.getAbsolutePath());
 
                 idResolver = new LegacyFSIDResolver(indexDir, f3DatastreamsDir);
-                objectSource = new NativeFoxmlDirectoryObjectSource(f3ObjectsDir, idResolver, localFedoraServer);
+                objectSource = new NativeFoxmlDirectoryObjectSource(f3ObjectsDir, idResolver, f3hostname);
                 break;
             default:
                 throw new RuntimeException("Should never happen");


### PR DESCRIPTION
This hostname is used to replace the default placeholder in 'E' and 'R' datastream URLs

Unit tests already exist for this functionality:
- https://github.com/fcrepo4-exts/migration-utils/blob/master/src/test/java/org/fcrepo/migration/Example1TestSuite.java#L18
and
- https://github.com/fcrepo4-exts/migration-utils/blob/master/src/test/java/org/fcrepo/migration/Example1TestSuite.java#L202

This update simply exposes the existing functionality as a user option

Resolves: https://jira.lyrasis.org/browse/FCREPO-3198

# How should this be tested?
1. Ensure that new option is shown in usage output
```
java -jar migration-utils.jar --help
```
   - Observe new `--f3hostname` option
2. Ensure functionality works
   - Find a test F3 object that contains either an `E` or `R` datastream (locally, I use: "1711.dl:CModelUWDCObject")
   - Run migration without the `-f` option
   - Inspect migrated object. It should contain a URL with `fedora.info` as host name
   - Remove migrated object
   - Run migration *with* the `-f` option. Specify any arbitrary value for the host name (e.g. "foo.bar")
   - Inspect migrated object. It should contain a URL with the provided host name

# Interested parties
Tag @fcrepo4/committers
