### PR TITLE
Ensure inventory state block contains all files for each version

### DIFF
--- a/src/main/java/org/fcrepo/migration/f4clients/OCFLFedora4Client.java
+++ b/src/main/java/org/fcrepo/migration/f4clients/OCFLFedora4Client.java
@@ -205,8 +205,8 @@ public class OCFLFedora4Client implements Fedora4Client {
         final File stagingObject = new File(stagingRoot, ocflObject);
         final User user = new User().setName("name").setAddress("address");
         final CommitInfo defaultCommitInfo = new CommitInfo().setMessage("message").setUser(user);
-        ocflRepo.putObject(ObjectVersionId.head(ocflObject), stagingObject.toPath(), defaultCommitInfo,
-                OcflOption.MOVE_SOURCE);
+        ocflRepo.updateObject(ObjectVersionId.head(ocflObject), defaultCommitInfo, updater -> {
+                updater.addPath(stagingObject.toPath(), OcflOption.MOVE_SOURCE, OcflOption.OVERWRITE);});
     }
 
     /**


### PR DESCRIPTION
Resolves: https://jira.lyrasis.org/browse/FCREPO-3209

# What does this Pull Request do?
Ensures inventory state block contains all files for each version

# How should this be tested?
1. Build and run migration-utils **without** this patch
   - Observe that the `state` block for any version (except the first) only contains the files changed in that version
1. Build and run migration-utils **with** this patch
   - Observe that the `state` block for any version (except the first) contains all files in that version

# Interested parties
@fcrepo4/committers, @pwinckles 
