### PR TITLE
update migration utils to produce F6 objects using the new layout

### DIFF
--- a/src/main/java/org/fcrepo/migration/handlers/ocfl/PersistencePaths.java
+++ b/src/main/java/org/fcrepo/migration/handlers/ocfl/PersistencePaths.java
@@ -1,0 +1,144 @@
+/*
+ * Licensed to DuraSpace under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * DuraSpace licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.fcrepo.migration.handlers.ocfl;
+
+/**
+ * This class maps Fedora resources to locations on disk. It is based on this wiki:
+ * https://wiki.lyrasis.org/display/FF/Design+-+Fedora+OCFL+Object+Structure
+ *
+ * This is a simplified implementation because F3 objects are always converted into flat AGs that only contain
+ * binaries and binary descriptions.
+ *
+ * @author pwinckles
+ * @since 6.0.0
+ */
+public final class PersistencePaths {
+
+    private static final String HEADER_DIR = ".fcrepo/";
+    private static final String ROOT_PREFIX = "fcr-root";
+    private static final String CONTAINER_PREFIX = "fcr-container";
+    private static final String DESCRIPTION_SUFFIX = "~fcr-desc";
+    private static final String RDF_EXTENSION = ".nt";
+    private static final String JSON_EXTENSION = ".json";
+
+    private enum ResourceType {
+        ROOT,
+        BINARY,
+        BINARY_DESCRIPTION;
+    }
+
+    private PersistencePaths() {
+        // static class
+    }
+
+    /**
+     * Constructs a path to a root header file.
+     *
+     * @param name the name of the resource
+     * @return path to the resource's root header file
+     */
+    public static String rootHeaderPath(final String name) {
+        return headerPath(ResourceType.ROOT, name);
+    }
+
+    /**
+     * Constructs a path to a binary header file.
+     *
+     * @param name the name of the resource
+     * @return path to a resource's binary header file
+     */
+    public static String binaryHeaderPath(final String name) {
+        return headerPath(ResourceType.BINARY, name);
+    }
+
+    /**
+     * Constructs a path to a binary description header file.
+     *
+     * @param name the name of the resource
+     * @return path to a resource's binary description header file
+     */
+    public static String binaryDescHeaderPath(final String name) {
+        return headerPath(ResourceType.BINARY_DESCRIPTION, name);
+    }
+
+    /**
+     * Constructs a path to a root content file.
+     *
+     * @param name the name of the resource
+     * @return path to the resource's root content file
+     */
+    public static String rootContentPath(final String name) {
+        return contentPath(ResourceType.ROOT, name);
+    }
+
+    /**
+     * Constructs a path to a binary content file.
+     *
+     * @param name the name of the resource
+     * @return path to a resource's binary content file
+     */
+    public static String binaryContentPath(final String name) {
+        return contentPath(ResourceType.BINARY, name);
+    }
+
+    /**
+     * Constructs a path to a root content file.
+     *
+     * @param name the name of the resource
+     * @return path to a resource's binary description content file
+     */
+    public static String binaryDescContentPath(final String name) {
+        return contentPath(ResourceType.BINARY_DESCRIPTION, name);
+    }
+
+    private static String headerPath(final ResourceType type, final String name) {
+        String path;
+
+        if (type == ResourceType.ROOT) {
+            path = ROOT_PREFIX;
+        } else {
+            path = name;
+        }
+
+        if (type == ResourceType.BINARY_DESCRIPTION) {
+            path += DESCRIPTION_SUFFIX;
+        }
+
+        return headerPath(path);
+    }
+
+    private static String contentPath(final ResourceType type, final String name) {
+        if (type == ResourceType.ROOT) {
+            return CONTAINER_PREFIX + RDF_EXTENSION;
+        }
+
+        var path = name;
+
+        if (type == ResourceType.BINARY_DESCRIPTION) {
+            path += DESCRIPTION_SUFFIX + RDF_EXTENSION;
+        }
+
+        return path;
+    }
+
+    private static String headerPath(final String path) {
+        return HEADER_DIR + path + JSON_EXTENSION;
+    }
+
+}

--- a/src/main/java/org/fcrepo/migration/handlers/ocfl/ResourceHeaders.java
+++ b/src/main/java/org/fcrepo/migration/handlers/ocfl/ResourceHeaders.java
@@ -65,6 +65,8 @@ public class ResourceHeaders {
 
     private boolean deleted;
 
+    private String contentPath;
+
     /**
      * @return the fedora id
      */
@@ -309,6 +311,20 @@ public class ResourceHeaders {
         return deleted;
     }
 
+    /**
+     * @return the path to the associated content file
+     */
+    public String getContentPath() {
+        return contentPath;
+    }
+
+    /**
+     * @param contentPath the path to the associated content file
+     */
+    public void setContentPath(final String contentPath) {
+        this.contentPath = contentPath;
+    }
+
     @Override
     public String toString() {
         return "ResourceHeaders{" +
@@ -329,6 +345,7 @@ public class ResourceHeaders {
                 ", archivalGroup=" + archivalGroup +
                 ", objectRoot=" + objectRoot +
                 ", deleted=" + deleted +
+                ", contentPath='" + contentPath + '\'' +
                 '}';
     }
 

--- a/src/test/java/org/fcrepo/migration/handlers/ocfl/ArchiveGroupHandlerTest.java
+++ b/src/test/java/org/fcrepo/migration/handlers/ocfl/ArchiveGroupHandlerTest.java
@@ -359,7 +359,8 @@ public class ArchiveGroupHandlerTest {
                                      final String parentId,
                                      final int index) {
         final var captor = ArgumentCaptor.forClass(InputStream.class);
-        verify(session, atLeastOnce()).put(eq(".fcrepo/" + path + ".json"), captor.capture());
+        verify(session, atLeastOnce()).put(eq(PersistencePaths.binaryHeaderPath(path)),
+                captor.capture());
         try {
             final var headers = objectMapper.readValue(captor.getAllValues().get(index), ResourceHeaders.class);
             assertEquals(FCREPO_ROOT + parentId + "/" + path, headers.getId());
@@ -379,6 +380,7 @@ public class ArchiveGroupHandlerTest {
                     String.valueOf(Instant.parse(datastreamVersion.getCreated()).toEpochMilli())).toUpperCase(),
                     headers.getStateToken());
             assertEquals(1, headers.getDigests().size());
+            assertEquals(PersistencePaths.binaryContentPath(path), headers.getContentPath());
             assertEquals(datastreamVersion.getExternalOrRedirectURL(), headers.getExternalUrl());
             if (Objects.equals("R", datastreamVersion.getDatastreamInfo().getControlGroup())) {
                 assertEquals("redirect", headers.getExternalHandling());
@@ -395,7 +397,8 @@ public class ArchiveGroupHandlerTest {
                                          final String objectId,
                                          final int index) {
         final var captor = ArgumentCaptor.forClass(InputStream.class);
-        verify(session, atLeastOnce()).put(eq(".fcrepo/" + dsId + "-description.json"), captor.capture());
+        verify(session, atLeastOnce()).put(eq(PersistencePaths.binaryDescHeaderPath(dsId)),
+                captor.capture());
         try {
             final var parentId = FCREPO_ROOT + objectId + "/" + dsId;
             final var headers = objectMapper.readValue(captor.getAllValues().get(index), ResourceHeaders.class);
@@ -407,6 +410,7 @@ public class ArchiveGroupHandlerTest {
             assertFalse("not deleted", headers.isDeleted());
             assertEquals(USER, headers.getCreatedBy());
             assertEquals(USER, headers.getLastModifiedBy());
+            assertEquals(PersistencePaths.binaryDescContentPath(dsId), headers.getContentPath());
             assertThat(headers.getLastModifiedDate().toString(), containsString(date));
             assertThat(headers.getCreatedDate().toString(), containsString(date));
         } catch (IOException e) {
@@ -417,7 +421,7 @@ public class ArchiveGroupHandlerTest {
     private void putObjectHeadersAndVerify(final OcflSession session,
                                              final String objectId) {
         final var captor = ArgumentCaptor.forClass(InputStream.class);
-        verify(session).put(eq(".fcrepo/" + objectId + ".json"), captor.capture());
+        verify(session).put(eq(PersistencePaths.rootHeaderPath(objectId)), captor.capture());
         try {
             final var headers = objectMapper.readValue(captor.getValue(), ResourceHeaders.class);
             assertEquals(FCREPO_ROOT + objectId, headers.getId());
@@ -428,6 +432,7 @@ public class ArchiveGroupHandlerTest {
             assertFalse("not deleted", headers.isDeleted());
             assertEquals(USER, headers.getCreatedBy());
             assertEquals(USER, headers.getLastModifiedBy());
+            assertEquals(PersistencePaths.rootContentPath(objectId), headers.getContentPath());
             assertThat(headers.getLastModifiedDate().toString(), containsString(date));
             assertThat(headers.getCreatedDate().toString(), containsString(date));
         } catch (IOException e) {
@@ -440,7 +445,8 @@ public class ArchiveGroupHandlerTest {
                                    final DatastreamVersion datastreamVersion,
                                    final int index) {
         final var captor = ArgumentCaptor.forClass(InputStream.class);
-        verify(session, atLeastOnce()).put(eq(path + "-description.nt"), captor.capture());
+        verify(session, atLeastOnce()).put(eq(PersistencePaths.binaryDescContentPath(path)),
+                captor.capture());
         try {
             final var value = IOUtils.toString(captor.getAllValues().get(index));
             assertThat(value, allOf(
@@ -458,7 +464,8 @@ public class ArchiveGroupHandlerTest {
                                    final DatastreamVersion datastreamVersion,
                                    final int index) {
         final var captor = ArgumentCaptor.forClass(InputStream.class);
-        verify(session, atLeastOnce()).put(eq(path + "-description.nt"), captor.capture());
+        verify(session, atLeastOnce()).put(eq(PersistencePaths.binaryDescContentPath(path)),
+                captor.capture());
         try {
             final var value = IOUtils.toString(captor.getAllValues().get(index));
             assertThat(value, allOf(
@@ -479,7 +486,7 @@ public class ArchiveGroupHandlerTest {
 
     private void putObjectRdfAndVerify(final OcflSession session, final String path) {
         final var captor = ArgumentCaptor.forClass(InputStream.class);
-        verify(session).put(eq(path + ".nt"), captor.capture());
+        verify(session).put(eq(PersistencePaths.rootContentPath(path)), captor.capture());
         try {
             final var value = IOUtils.toString(captor.getValue());
             assertThat(value, allOf(

--- a/src/test/java/org/fcrepo/migration/handlers/ocfl/PersistencePathsTest.java
+++ b/src/test/java/org/fcrepo/migration/handlers/ocfl/PersistencePathsTest.java
@@ -1,0 +1,71 @@
+/*
+ * Licensed to DuraSpace under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * DuraSpace licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.fcrepo.migration.handlers.ocfl;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * @author pwinckles
+ */
+public class PersistencePathsTest {
+
+    private static final String FCREPO_DIR = ".fcrepo/";
+    private static final String JSON = ".json";
+    private static final String NT = ".nt";
+    private static final String DESC_SUFFIX = "~fcr-desc";
+
+    @Test
+    public void mapRootToHeaderPath() {
+        assertEquals(FCREPO_DIR + "fcr-root" + JSON,
+                PersistencePaths.rootHeaderPath("blah"));
+    }
+
+    @Test
+    public void mapRootToContentPath() {
+        assertEquals("fcr-container" + NT,
+                PersistencePaths.rootContentPath("blah"));
+    }
+
+    @Test
+    public void mapBinaryToHeaderPath() {
+        assertEquals(FCREPO_DIR + "blah" + JSON,
+                PersistencePaths.binaryHeaderPath("blah"));
+    }
+
+    @Test
+    public void mapBinaryToContentPath() {
+        assertEquals("blah",
+                PersistencePaths.binaryContentPath("blah"));
+    }
+
+    @Test
+    public void mapBinaryDescToHeaderPath() {
+        assertEquals(FCREPO_DIR + "blah" + DESC_SUFFIX + JSON,
+                PersistencePaths.binaryDescHeaderPath("blah"));
+    }
+
+    @Test
+    public void mapBinaryDescToContentPath() {
+        assertEquals("blah" + DESC_SUFFIX + NT,
+                PersistencePaths.binaryDescContentPath("blah"));
+    }
+
+}


### PR DESCRIPTION
**JIRA Ticket**: https://jira.lyrasis.org/browse/FCREPO-3376

# What does this Pull Request do?

Updates the migration utils to produce F6 objects using the new layout (https://wiki.lyrasis.org/display/FF/Design+-+Fedora+OCFL+Object+Structure)

F6 in main has not been updated yet to support this format, so this PR should not be merged until it has.

# How should this be tested?

Run the migration utils and start F6 on the output.

# Interested parties
@fcrepo4/committers
