### PR TITLE
Adds support for --continue-on-error (-c) parameter to support contin…

### DIFF
--- a/src/main/java/org/fcrepo/migration/Migrator.java
+++ b/src/main/java/org/fcrepo/migration/Migrator.java
@@ -143,12 +143,8 @@ public class Migrator {
     public void run() throws XMLStreamException {
         int index = 0;
 
-        final var iterator = source.iterator();
-        while (true) {
+        for (final var iterator = source.iterator(); iterator.hasNext();) {
             try {
-                if (!iterator.hasNext()) {
-                    break;
-                }
                 final var o = iterator.next();
                 final String pid = o.getObjectInfo().getPid();
                 if (pid != null) {

--- a/src/main/java/org/fcrepo/migration/PicocliMigrator.java
+++ b/src/main/java/org/fcrepo/migration/PicocliMigrator.java
@@ -101,6 +101,10 @@ public class PicocliMigrator implements Callable<Integer> {
             description = "Resume from last successfully migrated Fedora 3 object")
     private boolean resume;
 
+    @Option(names = {"--continue-on-error", "-c"}, defaultValue = "false", showDefaultValue = ALWAYS, order = 22,
+            description = "Continue to next PID if an error occurs (instead of exiting). Disabled by default.")
+    private boolean continueOnError;
+
     @Option(names = {"--pid-file", "-p"}, order = 23,
             description = "PID file listing which Fedora 3 objects to migrate")
     private File pidFile;
@@ -255,6 +259,7 @@ public class PicocliMigrator implements Callable<Integer> {
         migrator.setSource(objectSource);
         migrator.setHandler(objectHandler);
         migrator.setPidListManagers(pidListManagerList);
+        migrator.setContinueOnError(continueOnError);
 
         try {
             migrator.run();


### PR DESCRIPTION
…uing to the next PID in the event that a PID cannot be migrated.

**JIRA Ticket**: https://jira.lyrasis.org/browse/FCREPO-3402

* Other Relevant Links (Mailing list discussion, related pull requests, etc.)

# What does this Pull Request do?
This PR introduces a flag for indicating the user wishes continue processing if it encounters a problem migrating an object.

# How should this be tested?
1. Perform a migration on an f3 repository with several objects. For example:
```
java -jar target/migration-utils-4.4.1-SNAPSHOT-driver.jar     --source-type=akubra  --limit=100 --target-dir=target/test/ocfl --objects-dir=/tmp/uw-madison-fedora-3-sample/objects --datastreams-dir=/tmp/uw-madison-fedora-3-sample/datastreams
```
2. Verify that it is successful.
3. Choose an object to "break" by introducing illegal XML or some other problem to F3 object or datastream.
For example in the uw-madison data set add some invalid xml to 
```
/tmp/uw-madison-fedora-3-sample/objectsdlmap/0/0e/9e/info%3Afedora%2F1711.dl%3AOLJYDSZAWI26F8D
```
4. Run again,  verify that the program halts when it reaches that object, reports the error an error to the console output and exits.
5. Run again with the -c flag and verify that the error is logged, but continues to process the rest of the PIDs.


# Interested parties
Tag (@ mention) interested parties or, if unsure, @fcrepo4/committers
